### PR TITLE
updates base hyku templates to use softserv versions

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,20 +1,18 @@
-### Descriptive summary
+# Story
 
-Include what version of Hyku relates to this issue (0.x, 1.x, HEAD, etc.) if appropriate, and any relevant tracebacks if you're reporting a bug.
+# Acceptance Criteria
 
-### Rationale
+- [ ]
 
-Provide the rationale or user story that describes "why" this issue should be addressed. Especially if this is a new feature or significant change to the existing implementation.
+# Screenshots / Video
 
-### Expected behavior
+<details>
+<summary></summary>
 
-### Actual behavior
+</details>
 
-### Steps to reproduce the behavior
+# Testing Instructions and Sample Files
 
-1. Do this
-1. Then do this...
+-
 
-### Related work
-
-Link to related tickets or prior related work here.
+# Notes

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,22 +1,16 @@
-Fixes #issuenumber ; refs #issuenumber
+# Story
 
-Present tense short summary (50 characters or less)
+Refs #issuenumber
 
-More detailed description, if necessary. Try to be as descriptive as you can: even if you think that the PR content is obvious, it may not be obvious to others. Include tracebacks if helpful, and be sure to call out any bits of the PR that may be work-in-progress.
+# Expected Behavior Before Changes
 
-Description can have multiple paragraphs and you can use code examples inside:
+# Expected Behavior After Changes
 
-``` ruby
-class PostsController
-  def index
-    respond_with Post.limit(10)
-  end
-end
-```
+# Screenshots / Video
 
-Changes proposed in this pull request:
-*
-*
-*
+<details>
+<summary></summary>
 
-@samvera/hyku-code-reviewers
+</details>
+
+# Notes


### PR DESCRIPTION
Refs https://github.com/scientist-softserv/dev-ops/issues/630

Hyku projects come with their own issue and PR templates from base Hyku. This PR updates these templates for the versions we've developed at SoftServ.