### PR TITLE
embedded iframe for videos

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,18 @@
-# Hyku, the Hydra-in-a-Box Repository Application
+# ATLA Hyku
+## Project Specific Info
+### Youtube/Vimeo Video Player For Works
+- Works will have the option to add a youtube or vimeo player via an embed link
+- This link must be a correctly formatted embed link from either youtube or vimeo.
+- To find this link:
+    - Navigate to the url of the video you would like to include.
+    - Click the "share" button
+    - You will see a link or a section called "Embed". View the embed code for the video
+    - Copy JUST the link. The link will be formatted as so for Youtube and Vimeo respectively:
+      - https://www.youtube.com/embed/Znf73dsFdC8
+      - https://player.vimeo.com/video/467264493?h=b089de0eab
+
+----
+# Default Hyku READme:
 
 Code:
 [![Build Status](https://circleci.com/gh/samvera/hyku.svg?style=svg)](https://circleci.com/gh/samvera/hyku)

--- a/README.md
+++ b/README.md
@@ -1,18 +1,4 @@
-# ATLA Hyku
-## Project Specific Info
-### Youtube/Vimeo Video Player For Works
-- Works will have the option to add a youtube or vimeo player via an embed link
-- This link must be a correctly formatted embed link from either youtube or vimeo.
-- To find this link:
-    - Navigate to the url of the video you would like to include.
-    - Click the "share" button
-    - You will see a link or a section called "Embed". View the embed code for the video
-    - Copy JUST the link. The link will be formatted as so for Youtube and Vimeo respectively:
-      - https://www.youtube.com/embed/Znf73dsFdC8
-      - https://player.vimeo.com/video/467264493?h=b089de0eab
-
-----
-# Default Hyku READme:
+# Hyku, the Hydra-in-a-Box Repository Application
 
 Code:
 [![Build Status](https://circleci.com/gh/samvera/hyku.svg?style=svg)](https://circleci.com/gh/samvera/hyku)

--- a/Repo_README.md
+++ b/Repo_README.md
@@ -1,0 +1,12 @@
+# ATLA Hyku
+## Project Specific Info
+### Youtube/Vimeo Video Player For Works
+- Works will have the option to add a youtube or vimeo player via an embed link
+- This link must be a correctly formatted embed link from either youtube or vimeo.
+- To find this link:
+    - Navigate to the url of the video you would like to include.
+    - Click the "share" button
+    - You will see a link or a section called "Embed". View the embed code for the video
+    - Copy JUST the link. The link will be formatted as so for Youtube and Vimeo respectively:
+      - https://www.youtube.com/embed/Znf73dsFdC8
+      - https://player.vimeo.com/video/467264493?h=b089de0eab

--- a/app/assets/stylesheets/viewer.scss
+++ b/app/assets/stylesheets/viewer.scss
@@ -5,9 +5,6 @@
 .viewer {
   height: 100%;
   padding: 10px;
-  iframe {
-    // position: absolute;
-  }
 }
 
 #viewer-modal {
@@ -20,4 +17,9 @@
   button.close {
     margin-bottom: 10px;
   }
+}
+
+.video-embed-viewer {
+  aspect-ratio: 16 / 9;
+  width: 100%;
 }

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -7,6 +7,6 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
-    self.terms += %i[resource_type]
+    self.terms += %i[resource_type video_embed]
   end
 end

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -8,5 +8,9 @@ module Hyrax
     self.model_class = ::GenericWork
     include HydraEditor::Form::Permissions
     self.terms += %i[resource_type video_embed]
+
+    def primary_terms
+      super + %i[video_embed]
+    end
   end
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -9,20 +9,22 @@ class GenericWork < ActiveFedora::Base
   self.indexer = GenericWorkIndexer
 
   validates :title, presence: { message: 'Your work must have a title.' }
+  # rubocop:disable Style/RegexpLiteral
   validates :video_embed,
-  format: {
-    # regex matches only youtube & vimeo urls that are formatted as embed links.
-    with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
-    message: "Error: must be a valid YouTube or Vimeo Embed URL." },
-  if: :video_embed?
-
+            format: {
+              # regex matches only youtube & vimeo urls that are formatted as embed links.
+              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+              message: "Error: must be a valid YouTube or Vimeo Embed URL."
+            },
+            if: :video_embed?
+  # rubocop:enable Style/RegexpLiteral
 
   property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
     index.as :stored_searchable
   end
 
   def video_embed?
-    video_embed.present? && !video_embed.blank?
+    video_embed.present?
   end
 
   # This must be included at the end of the file,

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -9,6 +9,12 @@ class GenericWork < ActiveFedora::Base
   self.indexer = GenericWorkIndexer
 
   validates :title, presence: { message: 'Your work must have a title.' }
+  validates :video_embed,
+  format: {
+    with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+    message: "Error: must be a valid YouTube or Vimeo Embed URL." },
+  if: :video_embed?
+
 
   property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
     index.as :stored_searchable

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -2,12 +2,24 @@
 
 class GenericWork < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
-  include ::Hyrax::BasicMetadata
   include IiifPrint.model_configuration(
     pdf_split_child_model: self
   )
+  # this line needs to be before the validations & properties in order for them to be indexed correctly
+  self.indexer = GenericWorkIndexer
 
   validates :title, presence: { message: 'Your work must have a title.' }
 
-  self.indexer = GenericWorkIndexer
+  property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/video_embed"), multiple: false do |index|
+    index.as :stored_searchable
+  end
+
+  def video_embed?
+    video_embed.present? && !video_embed.blank?
+  end
+
+  # This must be included at the end of the file,
+  # This line finalizes the metadata schema
+  # (by adding accepts_nested_attributes)
+  include ::Hyrax::BasicMetadata
 end

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -11,6 +11,7 @@ class GenericWork < ActiveFedora::Base
   validates :title, presence: { message: 'Your work must have a title.' }
   validates :video_embed,
   format: {
+    # regex matches only youtube & vimeo urls that are formatted as embed links.
     with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
     message: "Error: must be a valid YouTube or Vimeo Embed URL." },
   if: :video_embed?

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -30,6 +30,7 @@ class SolrDocument
   attribute :extent, Solr::Array, 'extent_tesim'
   attribute :rendering_ids, Solr::Array, 'hasFormat_ssim'
   attribute :account_cname, Solr::Array, 'account_cname_tesim'
+  attribute :video_embed, Solr::String, 'video_embed_tesim'
 
   field_semantics.merge!(
     contributor: 'contributor_tesim',

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -71,6 +71,7 @@ module Hyku
     end
 
     private
+
       def extract_video_embed_presence
         solr_document[:video_embed_tesim].present?
       end

--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -66,7 +66,14 @@ module Hyku
         members_include_viewable?
     end
 
+    def video_embed_viewer?
+      extract_video_embed_presence
+    end
+
     private
+      def extract_video_embed_presence
+        solr_document[:video_embed_tesim].present?
+      end
 
       def iiif_media?(presenter: representative_presenter)
         presenter.image? || presenter.video? || presenter.audio? || presenter.pdf?

--- a/app/views/hyrax/base/_form.html.erb
+++ b/app/views/hyrax/base/_form.html.erb
@@ -1,0 +1,24 @@
+<%# OVERRIDE Hyrax 3.5.0 to remove the broken error alerts from form validations %>
+
+<%= simple_form_for [main_app, @form],
+                    html: {
+                      data: { behavior: 'work-form',
+                              'param-key' => @form.model_name.param_key },
+                      multipart: true
+                    } do |f| %>
+  <%# OVERRIDE Here to remove broken error alert from form validation %>
+  <% if Flipflop.batch_upload? && !f.object.persisted? %>
+    <% provide :metadata_tab do %>
+      <p class="switch-upload-type"><%= t('.batch_upload_hint') %> <%= link_to t('.batch_link'), hyrax.new_batch_upload_path(payload_concern: @form.model.class) %></p>
+    <% end %>
+  <% end %>
+  <%= render 'hyrax/base/guts4form', f: f, tabs: form_tabs_for(form: f.object) %>
+<% end %>
+
+<script type="text/javascript">
+  Blacklight.onLoad(function() {
+    <%# This causes the page to switch back to the default template if they've
+        previously visited the batch download page in this Turbolinks session %>
+    $("#fileupload").fileupload('option', 'downloadTemplateId', 'template-download')
+  });
+</script>

--- a/app/views/hyrax/base/_video_embed_viewer.html.erb
+++ b/app/views/hyrax/base/_video_embed_viewer.html.erb
@@ -1,0 +1,3 @@
+<div class="col-sm-12">
+  <iframe class='video-embed-viewer' src="<%="#{@presenter.solr_document[:video_embed_tesim].first}"%>" title="Video Player" frameborder="0" allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture; web-share" allowfullscreen></iframe>
+</div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -18,7 +18,7 @@
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
           <% end %>
-          <% if @presenter.iiif_viewer? & !@presenter.video_embed_viewer? %>
+          <% if @presenter.iiif_viewer? && !@presenter.video_embed_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -17,19 +17,25 @@
           <%= render 'workflow_actions_widget', presenter: @presenter %>
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% else %>
+            <% if @presenter.iiif_viewer? %>
+              <div class="col-sm-12">
+                <%= render 'representative_media', presenter: @presenter, viewer: true %>
+              </div>
+            <% else %>
+              <div class="col-sm-3 text-center">
+                <%= render 'representative_media', presenter: @presenter, viewer: false %>
+                <%= render 'citations', presenter: @presenter %>
+                <%= render 'social_media' %>
+              </div>
+            <% end %>
           <% end %>
-          <% if @presenter.iiif_viewer? && !@presenter.video_embed_viewer? %>
-            <div class="col-sm-12">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
+          <% if @presenter.iiif_viewer? || @presenter.video_embed_viewer?%>
+            <div class="col-sm-3 text-center">
+              <%= render 'citations', presenter: @presenter %>
+              <%= render 'social_media' %>
             </div>
           <% end %>
-          <div class="col-sm-3 text-center">
-            <% if !@presenter.video_embed_viewer? %>
-              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
-            <% end %>
-            <%= render 'citations', presenter: @presenter %>
-            <%= render 'social_media' %>
-          </div>
           <div class="col-sm-9">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>

--- a/app/views/hyrax/base/show.html.erb
+++ b/app/views/hyrax/base/show.html.erb
@@ -15,13 +15,18 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.iiif_viewer? %>
+          <% if @presenter.video_embed_viewer? %>
+            <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% end %>
+          <% if @presenter.iiif_viewer? & !@presenter.video_embed_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
           <% end %>
           <div class="col-sm-3 text-center">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.iiif_viewer? %>
+            <% if !@presenter.video_embed_viewer? %>
+              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <% end %>
             <%= render 'citations', presenter: @presenter %>
             <%= render 'social_media' %>
           </div>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -20,7 +20,7 @@
       <div class="main-content maximized">
         <%# OVERRIDE here to hide broken flash messages on the dashboard edit work pages. %>
         <%# regex includes only the paths for works since this is the only known place flash messages are broken. %>
-        <% if (current_ability.admin? || current_ability.superadmin?) && !controller.request.env['REQUEST_PATH'].include?('concern') %>
+        <% if (current_ability.admin? || current_ability.superadmin?) && !controller&.request&.env['REQUEST_PATH']&.include?('concern') %>
           <%= render '/flash_msg' %>
         <% end %>
         <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -1,0 +1,44 @@
+<%# OVERRIDE from Hyrax 3.5.0 to hide broken flash messages on the dashboard edit work pages %>
+
+<!DOCTYPE html>
+<html lang="<%= I18n.locale.to_s %>" prefix="og:http://ogp.me/ns#">
+  <head>
+    <%= render partial: 'layouts/head_tag_content' %>
+    <%= content_for(:head) %>
+  </head>
+
+  <body class="dashboard">
+    <div class="skip-to-content">
+      <%= link_to "Skip to Content", "#skip-to-content" %>
+    </div>
+    <%= render '/masthead' %>
+    <%= content_for(:navbar) %>
+    <div id="content-wrapper" role="main">
+      <div class="sidebar maximized">
+        <%= render 'hyrax/dashboard/sidebar' %>
+      </div>
+      <div class="main-content maximized">
+        <%# OVERRIDE here to hide broken flash messages on the dashboard edit work pages. %>
+        <%# regex includes only the paths for works since this is the only known place flash messages are broken. %>
+        <% if !controller.request.env['REQUEST_PATH'].include?('concern') %>
+          <%= render '/flash_msg' %>
+        <% end %>
+        <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
+        <% if content_for?(:page_header) %>
+          <div class="row">
+            <div class="col-xs-12 main-header">
+              <%= yield(:page_header) %>
+            </div>
+          </div>
+        <% end %>
+
+          <a name="skip-to-content" id="skip-to-content"></a>
+          <%= render 'shared/read_only' if Flipflop.read_only? %>
+          <%= content_for?(:content) ? yield(:content) : yield %>
+
+      </div>
+
+    </div><!-- /#content-wrapper -->
+    <%= render 'shared/ajax_modal' %>
+  </body>
+</html>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -20,7 +20,7 @@
       <div class="main-content maximized">
         <%# OVERRIDE here to hide broken flash messages on the dashboard edit work pages. %>
         <%# regex includes only the paths for works since this is the only known place flash messages are broken. %>
-        <% if !controller.request.env['REQUEST_PATH'].include?('concern') %>
+        <% if (current_ability.admin? || current_ability.superadmin?) && !controller.request.env['REQUEST_PATH'].include?('concern') %>
           <%= render '/flash_msg' %>
         <% end %>
         <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>

--- a/app/views/layouts/hyrax/dashboard.html.erb
+++ b/app/views/layouts/hyrax/dashboard.html.erb
@@ -20,9 +20,8 @@
       <div class="main-content maximized">
         <%# OVERRIDE here to hide broken flash messages on the dashboard edit work pages. %>
         <%# regex includes only the paths for works since this is the only known place flash messages are broken. %>
-        <% if (current_ability.admin? || current_ability.superadmin?) && !controller&.request&.env['REQUEST_PATH']&.include?('concern') %>
           <%= render '/flash_msg' %>
-        <% end %>
+          <%#= raise 'hell' %>
         <%= render_breadcrumbs builder: Hyrax::BootstrapBreadcrumbsBuilder %>
         <% if content_for?(:page_header) %>
           <div class="row">

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -11,21 +11,21 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.video_embed_viewer? %>
-            <%= render 'video_embed_viewer', presenter: @presenter %>
-          <% end %>
-          <% if @presenter.universal_viewer? && !@presenter.video_embed_viewer? %>
-            <div class="col-sm-12 centered-media">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
-            </div>
-          <% end %>
           <div class="col-sm-12">
             <%= render "show_actions", presenter: @presenter %>
           </div>
-          <% if !@presenter.video_embed_viewer? %>
-            <div class="centered-media <%= !@presenter.universal_viewer? ? 'col-sm-6 text-center' : '' %>">
-              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
-            </div>
+          <% if @presenter.video_embed_viewer? %>
+            <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% else %>
+            <% if @presenter.universal_viewer? %>
+              <div class="col-sm-12 centered-media">
+                <%= render 'representative_media', presenter: @presenter, viewer: true %>
+              </div>
+            <% else %>
+              <div class="centered-media <%= !@presenter.universal_viewer? ? 'col-sm-6 text-center' : '' %>">
+                <%= render 'representative_media', presenter: @presenter, viewer: false %>
+              </div>
+            <% end %>
           <% end %>
           <div class="<%= @presenter.universal_viewer? ? 'col-sm-6' : 'col-sm-6' %>">
             <%= render 'work_description', presenter: @presenter %>

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -14,7 +14,7 @@
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
           <% end %>
-          <% if @presenter.universal_viewer? & !@presenter.video_embed_viewer? %>
+          <% if @presenter.universal_viewer? && !@presenter.video_embed_viewer? %>
             <div class="col-sm-12 centered-media">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>

--- a/app/views/themes/cultural_show/hyrax/base/show.html.erb
+++ b/app/views/themes/cultural_show/hyrax/base/show.html.erb
@@ -11,7 +11,10 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
+          <% if @presenter.video_embed_viewer? %>
+            <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% end %>
+          <% if @presenter.universal_viewer? & !@presenter.video_embed_viewer? %>
             <div class="col-sm-12 centered-media">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
@@ -19,9 +22,11 @@
           <div class="col-sm-12">
             <%= render "show_actions", presenter: @presenter %>
           </div>
-          <div class="centered-media <%= !@presenter.universal_viewer? ? 'col-sm-6 text-center' : '' %>">
-            <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
-          </div>
+          <% if !@presenter.video_embed_viewer? %>
+            <div class="centered-media <%= !@presenter.universal_viewer? ? 'col-sm-6 text-center' : '' %>">
+              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            </div>
+          <% end %>
           <div class="<%= @presenter.universal_viewer? ? 'col-sm-6' : 'col-sm-6' %>">
             <%= render 'work_description', presenter: @presenter %>
             <%= render 'metadata', presenter: @presenter %>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -19,7 +19,7 @@
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
           <% end %>
-          <% if @presenter.universal_viewer? & !@presenter.video_embed_viewer? %>
+          <% if @presenter.universal_viewer? && !@presenter.video_embed_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -16,7 +16,10 @@
       <div class="panel-body">
         <div class="row">
           <%= render 'workflow_actions_widget', presenter: @presenter %>
-          <% if @presenter.universal_viewer? %>
+          <% if @presenter.video_embed_viewer? %>
+            <%= render 'video_embed_viewer', presenter: @presenter %>
+          <% end %>
+          <% if @presenter.universal_viewer? & !@presenter.video_embed_viewer? %>
             <div class="col-sm-12">
               <%= render 'representative_media', presenter: @presenter, viewer: true %>
             </div>
@@ -24,18 +27,20 @@
               <div class="image-show-description">
                 <%= render 'work_description', presenter: @presenter %>
               </div>
-            </div> 
-          <% else %>
-            <div class="col-sm-3 mb-1">
-              <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
             </div>
+          <% else %>
+            <% if !@presenter.video_embed_viewer? %>
+              <div class="col-sm-3 mb-1">
+                <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+              </div>
+              <% end %>
             <div class="col-sm-9">
               <%= render 'work_description', presenter: @presenter %>
             </div>
           <% end %>
         </div>
         <div class="row">
-          <div class="col-sm-12 image-show-metadata">  
+          <div class="col-sm-12 image-show-metadata">
             <%= render 'metadata', presenter: @presenter %>
           </div>
           <div class="col-sm-12">

--- a/app/views/themes/scholarly_show/hyrax/base/show.html.erb
+++ b/app/views/themes/scholarly_show/hyrax/base/show.html.erb
@@ -18,25 +18,29 @@
           <%= render 'workflow_actions_widget', presenter: @presenter %>
           <% if @presenter.video_embed_viewer? %>
             <%= render 'video_embed_viewer', presenter: @presenter %>
-          <% end %>
-          <% if @presenter.universal_viewer? && !@presenter.video_embed_viewer? %>
-            <div class="col-sm-12">
-              <%= render 'representative_media', presenter: @presenter, viewer: true %>
-            </div>
             <div class="col-sm-12">
               <div class="image-show-description">
                 <%= render 'work_description', presenter: @presenter %>
               </div>
             </div>
           <% else %>
-            <% if !@presenter.video_embed_viewer? %>
-              <div class="col-sm-3 mb-1">
-                <%= render 'representative_media', presenter: @presenter, viewer: false unless @presenter.universal_viewer? %>
+            <% if @presenter.universal_viewer? %>
+              <div class="col-sm-12 centered-media">
+                <%= render 'representative_media', presenter: @presenter, viewer: true %>
               </div>
-              <% end %>
-            <div class="col-sm-9">
-              <%= render 'work_description', presenter: @presenter %>
-            </div>
+              <div class="col-sm-12">
+                <div class="image-show-description">
+                  <%= render 'work_description', presenter: @presenter %>
+                </div>
+              </div>
+            <% else %>
+              <div class="col-sm-3 mb-1">
+                <%= render 'representative_media', presenter: @presenter, viewer: false %>
+              </div>
+              <div class="col-sm-9">
+                <%= render 'work_description', presenter: @presenter %>
+              </div>
+            <% end %>
           <% end %>
         </div>
         <div class="row">

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -64,6 +64,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
 
     config.field_mappings["Bulkrax::CsvParser"] = default_field_mapping.merge({
       # add or remove custom mappings for this parser here
+      'video_embed' => { from: ['video_embed'] }
     })
 
     config.field_mappings["Bulkrax::OaiDcParser"] = default_field_mapping.merge({

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1142,7 +1142,7 @@ en:
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
         subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a work.
-        video_embed: If you enter an embed link for a video, it must be a properly formatted url beginning with "http://". It also needs to contain a valid link to a hosted video that can appear in an iframe.
+        video_embed: "If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>"
     labels:
       collection:
         size: Size

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1142,6 +1142,7 @@ en:
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as &quot;article&quot; or &quot;dataset.&quot;  More than one type may be selected.
         subject: Headings or index terms describing what the work is about; these do need to conform to an existing vocabulary.
         title: A name to aid in identifying a work.
+        video_embed: If you enter an embed link for a video, it must be a properly formatted url beginning with "http://". It also needs to contain a valid link to a hosted video that can appear in an iframe.
     labels:
       collection:
         size: Size

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_02_08_001228) do
+ActiveRecord::Schema.define(version: 2023_01_31_202855) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"


### PR DESCRIPTION
# Story
SoftServ will customize the ability for YouTube videos to appear embedded on a work show page. Videos will not be played back in Universal Viewer.

# Related
- #9 

# Expected Behavior Before Changes
- all works that should show a UV show them
- users would only see either the uv viewer or default image

# Expected Behavior After Changes
- If a work has a valid `video_embed` link saved in its metadata, the work show page will show that video in an iframe.
- If a work does not have a valid `video_embed` link saved in its metadata, but should show the universal viewer because it has files, it shows the viewer.
- If a work does not have either `video_embed` metadata or files to show in the viewer, it shows the default image. 

# Screenshots / Video

<details>
<summary>Working youtube player</summary>
<img width="866" alt="image" src="https://user-images.githubusercontent.com/73361970/235522690-907357a7-0647-4892-859a-2e8ea3e0f4c3.png">

</details>

<details>
<summary>Working vimeo player</summary>
<img width="1036" alt="image" src="https://user-images.githubusercontent.com/73361970/235756224-8cf42a57-09c6-47dc-a3b7-8f5888fc01d3.png">

</details>

<details>
<summary>Form with error message for invalid url entry</summary>
<img width="657" alt="image" src="https://user-images.githubusercontent.com/73361970/235751107-8b9c9d25-db33-4f20-978d-8ba6587f0069.png">

</details>

# Acceptance
- [ ] Users should be able to add a video embed link from the work-edit page in the dashboard
- [ ] Users can see help text explaining the format for the links, as well as more in depth directions for how to find the link in the project readme
- [ ] The field should support embed links for either youtube or vimeo links
- [ ] The field should not support urls that are not valid youtube or vimeo links in the formats provided in the help text.
- [ ] On the work show page, the user should be able to see the embedded video if they add a link
- [ ] If there is no link added, the work show page will show the UV or the default image (behavior would be the same and prior to this implementation)
- [ ] All 3 show page (cultural, scholarly, default) themes should support the video-embed viewer

# Note
- ability to import the video-embed links with bulkrax will be done in the bulkrax configuration ticket
- this still needs to be added to the 2 other worktypes which are in flight
