### PR TITLE
Fix error message formatting for edit work form

### DIFF
--- a/app/controllers/concerns/hyrax/works_controller_behavior.rb
+++ b/app/controllers/concerns/hyrax/works_controller_behavior.rb
@@ -373,10 +373,17 @@ module Hyrax
         end
       end
 
+      def format_error_messages(errors)
+        errors.messages.map do |field, messages|
+          field_name = field.to_s.humanize
+          messages.map { |message| "#{field_name} #{message.sub(/^./, &:downcase)}" }
+        end.flatten.join("\n")
+      end
+
       def after_create_error(errors, original_input_params_for_form = nil)
         respond_to do |wants|
           wants.html do
-            flash[:error] = errors.to_s
+            flash[:error] = format_error_messages(errors)
             rebuild_form(original_input_params_for_form) if original_input_params_for_form.present?
             render 'new', status: :unprocessable_entity
           end
@@ -405,7 +412,7 @@ module Hyrax
       def after_update_error(errors)
         respond_to do |wants|
           wants.html do
-            flash[:error] = errors.to_s
+            flash[:error] = format_error_messages(errors)
             build_form unless @form.is_a? Hyrax::ChangeSet
             render 'edit', status: :unprocessable_entity
           end


### PR DESCRIPTION
# Story
Error messages from validations in the edit-work form were appearing as blank- the message was not being parsed correctly. This PR updates the works controller behavior to make sure that these error messages are being set.

# Related
- https://github.com/scientist-softserv/atla-hyku/issues/45
- #9 

# Expected Behavior Before Changes
- users would see a blank error message
![Image](https://user-images.githubusercontent.com/73361970/236267524-6a09b133-74cf-420b-8dfc-5da7081c68c5.png)

# Expected Behavior After Changes
- users will not see a blank error message at the top of the screen

# Screenshots / Video

<details>
<summary>Working error message for :video_embed</summary>

![screencapture-bulkraxtest-hyku-test-concern-generic-works-2023-05-04-11_15_40](https://user-images.githubusercontent.com/73361970/236268110-6a0ee40b-38d7-4b70-a299-6b1c8e5939c2.png)

</details>

# Notes
Potential contribute back to hyku