### PR TITLE
update mappings for OAI Hyku

### DIFF
--- a/lib/oai/provider/metadata_format/hyku_dublin_core.rb
+++ b/lib/oai/provider/metadata_format/hyku_dublin_core.rb
@@ -13,10 +13,14 @@ module OAI
           # Dublin Core Terms Fields
           # For new fields, add here first then add to #map_oai_hyku
           @fields = %i[
-            abstract access_right alternative_title based_near bibliographic_citation
-            contributor creator date_created date_modified date_uploaded depositor
-            description identifier keyword language license owner publisher related_url
-            resource_type rights_notes rights_statement source subject title
+            abstract access_right additional_rights_info advisor alternative_title based_near
+            bibliographic_citation committee_member contributor contributor_orcid contributor_institutional_relationship
+            contributor_role creator creator_institutional_relationship creator_orcid date_created
+            date_modified date_uploaded degree department depositor degree_granting_institution
+            description discipline event_date event_location event_title format funder_name funder_awards
+            identifier institution keyword language level license official_link owner project_name
+            publisher related_url resource_type rights_holder rights_notes rights_statement source
+            subject title year
           ]
         end
 

--- a/lib/oai/provider/model_decorator.rb
+++ b/lib/oai/provider/model_decorator.rb
@@ -4,33 +4,57 @@ module OAI
   module Provider
     module ModelDecorator
       # Map Qualified Dublin Core (Terms) fields to PALNI/PALCI fields
-      def map_oai_hyku
+      def map_oai_hyku # rubocop:disable Metrics/MethodLength
         {
           abstract: :abstract,
           access_right: :access_right,
+          additional_rights_info: :additional_rights_info,
+          advisor: :advisor,
           alternative_title: :alternative_title,
           based_near: :based_near,
           bibliographic_citation: :bibliographic_citation,
+          committee_member: :committee_member,
           contributor: :contributor,
+          contributor_institutional_relationship: :contributor_institutional_relationship,
+          contributor_orcid: :contributor_orcid,
+          contributor_role: :contributor_role,
           creator: :creator,
+          creator_institutional_relationship: :creator_institutional_relationship,
+          creator_orcid: :creator_orcid,
           date_created: :date_created,
           date_modified: :date_modified,
           date_uploaded: :date_uploaded,
+          degree: :degree,
+          degree_granting_institution: :degree_granting_institution,
+          department: :department,
           depositor: :depositor,
           description: :description,
+          discipline: :discipline,
+          event_date: :event_date,
+          event_location: :event_location,
+          event_title: :event_title,
+          format: :format,
+          funder_name: :funder_name,
+          funder_awards: :funder_awards,
           identifier: :identifier,
+          institution: :institution,
           keyword: :keyword,
           language: :language,
+          level: :level,
           license: :license,
+          official_link: :official_link,
           owner: :owner,
+          project_name: :project_name,
           publisher: :publisher,
           related_url: :related_url,
           resource_type: :resource_type,
+          rights_holder: :rights_holder,
           rights_notes: :rights_notes,
           rights_statement: :rights_statement,
           source: :source,
           subject: :subject,
-          title: :title
+          title: :title,
+          year: :year
         }
       end
     end


### PR DESCRIPTION
# Story

Refs #10 

Adds mappings for new metadata added to ETD and Paper or Report worktypes

# Expected Behavior Before Changes
OAI Hyku feed was missing new custom metadata fields
# Expected Behavior After Changes
OAI Hyku feed will have all metadata in the feed
# Screenshots / Video

<details>
<img width="827" alt="Screenshot 2023-05-10 at 2 52 22 PM" src="https://github.com/scientist-softserv/atla-hyku/assets/18175797/f0b665c4-6429-4a14-8b74-f5edd2cbed2f">


</details>

# Notes