### PR TITLE
Fix inheritance of indexers

### DIFF
--- a/app/indexers/etd_indexer.rb
+++ b/app/indexers/etd_indexer.rb
@@ -2,15 +2,7 @@
 
 # Generated via
 #  `rails generate hyrax:work Etd`
-class EtdIndexer < Hyrax::WorkIndexer
-  # This indexes the default metadata. You can remove it if you want to
-  # provide your own metadata and indexing.
-  include Hyrax::IndexesBasicMetadata
-
-  # Fetch remote labels for based_near. You can remove this if you don't want
-  # this behavior
-  include Hyrax::IndexesLinkedMetadata
-
+class EtdIndexer < AppIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   # def generate_solr_document
   #  super.tap do |solr_doc|

--- a/app/indexers/paper_or_report_indexer.rb
+++ b/app/indexers/paper_or_report_indexer.rb
@@ -3,15 +3,7 @@
 
 # Generated via
 #  `rails generate hyrax:work PaperOrReport`
-class PaperOrReportIndexer < Hyrax::WorkIndexer
-  # This indexes the default metadata. You can remove it if you want to
-  # provide your own metadata and indexing.
-  include Hyrax::IndexesBasicMetadata
-
-  # Fetch remote labels for based_near. You can remove this if you don't want
-  # this behavior
-  include Hyrax::IndexesLinkedMetadata
-
+class PaperOrReportIndexer < AppIndexer
   # Uncomment this block if you want to add custom indexing behavior:
   # def generate_solr_document
   #  super.tap do |solr_doc|


### PR DESCRIPTION
# Story
- the subject field was not parsing correctly for Etds because the corresponding generated indexer was not inheriting from the app_indexer.
- all worktype indexers should inherit from the app_indexer so that there is a way to add indexing methods in just one place that can apply across all worktypes

# Related
- #52 

# Expected Behavior Before Changes
- subject field was not parsing correctly for Etd works

# Expected Behavior After Changes
- subject field parses correctly for Etd works (the first letter will be capitalized, and any spaces or periods on the end will be stripped)

# Screenshots / Video

<details>
<summary>Etd with a subject</summary>

<img width="1083" alt="Screen Shot 2023-05-11 at 15 49 46" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/67f92fd6-c64c-47bc-aa0e-7654e1b0dc53">

</details>
