### PR TITLE
Cleanup yml, add link in rightsstatement

### DIFF
--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -9,19 +9,7 @@ en:
   simple_form:
     hints:
       defaults:
-        alternative_title: 'Alternative title for the resource.'
-        keyword: 'Words or phrases you select to describe what the work is about. These do not need to be a controlled vocabulary.'
-        rights_statement: 'Select the appropriate rights statement from the dropdown list. See https://rightsstatements.org for more information'
-        description: 'A free text account of the resource'
-        access_right: 'If access is restricted to a certain group of users or if the content is subject to embargo, include that information here.'
-        rights_notes: 'Any additional explanation of rights or licensing may be included here.'
-        publisher: 'The person or group responsible for making the original resource available.'
         year: 'The year in which the work was created. This should be a 4-digit number'
-        subject: 'Choose headings or index terms describing what the work is about from the our subject list. If your terms are missing from the list use FAST subject headings. For additional religion and theology terms that should be added to our list use this form.'
-        resource_type: 'Pre-defined categories to describe the type of content being uploaded, such as "article" or "photograph." More than one resource type may be selected.'
-        institution: 'Participating institution to which the work is being uploaded to.'
-        type: 'Pre-defined categories to describe the nature or genre of the resource. More than one type may be selected.'
-        format: 'The file format of the digital resource.'
         degree: 'Name of the degree associated with the work as it appears within the work.'
         level: 'Level of education associated with the document.'
         discipline: 'Area of study of the intellectual content of the document. Usually this will be the name of a program or department.'

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1145,7 +1145,7 @@ en:
         related_url: A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived.
         resource_type: Pre-defined categories to describe the type of content being uploaded, such as "article" or "photograph." More than one resource type may be selected.
         rights_notes: Any additional explanation of rights or licensing may be included here.
-        rights_statement: Select the appropriate rights statement from the dropdown list. See https://rightsstatements.org for more information.
+        rights_statement: Select the appropriate rights statement from the dropdown list. See <a href='https://rightsstatements.org'>https://rightsstatements.org</a> for more information.
         subject: Headings or index terms describing what the work is about.
         title: A name to aid in identifying a work.
         types: 'Pre-defined categories to describe the nature or genre of the resource. More than one type may be selected.'

--- a/config/locales/paper_or_report.en.yml
+++ b/config/locales/paper_or_report.en.yml
@@ -9,11 +9,6 @@ en:
   simple_form:
     hints:
       defaults:
-        keyword: "Words or phrases you select to describe what the work is about. These do not need to be a controlled vocabulary."
-        rights_statement: "Select the appropriate rights statement from the dropdown list. See https://rightsstatements.org for more information"
-        publisher: "The person or group responsible for making the original resource available."
-        institution: "Participating institution to which the work is being uploaded to."
-        format: "The file format of the digital resource."
         rights_holder: "A person or organization owning or managing rights over the resource."
         creator_orcid: "16 character ORCID identifier of creator."
         creator_institutional_relationship: "Relationship between the contributor and the institution hosting the work."


### PR DESCRIPTION
# Story
- rights statement help text should be a link
- removes properties in the other worktype's yaml that are repeated - they inherit from the value in `en.yaml` so they are not necessary

# Screenshot
<img width="1062" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/59139681-aa63-4485-8946-c08b8c68f2e4">
