### PR TITLE
Format rework

### DIFF
--- a/app/services/hyrax/format_service.rb
+++ b/app/services/hyrax/format_service.rb
@@ -1,10 +1,10 @@
 # frozen_string_literal: true
 
 module Hyrax
-  # Provide select options for the types field
   class FormatService < QaSelectService
     mattr_accessor :authority
     self.authority = Qa::Authorities::Local.subauthority_for('formats')
+
     def initialize(_authority_name = nil)
       super('formats')
     end
@@ -17,6 +17,21 @@ module Hyrax
 
     def self.label(id)
       authority.find(id).fetch('term')
+    end
+
+    def self.label_from_alt(alt)
+      alt.downcase!
+      label = authority.all.map do |element|
+        element[:label] if element[:label].downcase == alt || element[:alt_labels].include?(alt)
+      end .compact
+      label.blank? ? nil : label.first
+    end
+
+    # @param [String, nil] id identifier of the resource type
+    # @return [String] a schema.org type. Gives the default type if `id` is nil.
+    def self.microdata_type(id)
+      return Hyrax.config.microdata_default_type if id.nil?
+      Microdata.fetch("format.#{id}", default: Hyrax.config.microdata_default_type)
     end
   end
 end

--- a/app/views/records/edit_fields/_format.html.erb
+++ b/app/views/records/edit_fields/_format.html.erb
@@ -1,3 +1,8 @@
 <%# CUSTOM: app/views/records/edit_fields/_format.html.erb  %>
-<%= f.input :format, as: :multi_value_select, collection: Hyrax::FormatService.select_options,
-    input_html: { class: 'form-control', multiple: true } %>
+<% formats = Hyrax::FormatService.select_options.map { |format| format.first } %>
+<%= f.input :format,
+  collection: formats,
+  as: :multi_value_select,
+  include_blank: true,
+  input_html: { class: 'form-control', multiple: true }
+%>

--- a/config/authorities/formats.yml
+++ b/config/authorities/formats.yml
@@ -1,7 +1,32 @@
 terms:
-  - id: application/pdf
-    term: PDF
-    alts: ['pdf','application/pdf']
+  - id: audio/aac
+    term: AAC
+    alts: ['audio/aac']
+    active: true
+
+  - id: audio/aiff
+    term: AIFF
+    alts: ['audio/aiff']
+    active: true
+
+  - id: video/vnd.avi
+    term: AVI
+    alts: ['video/vnd.avi','video/avi']
+    active: true
+
+  - id: text/csv
+    term: CSV
+    alts: ['text/csv']
+    active: true
+
+  - id: image/gif
+    term: GIF
+    alts: ['image/gif']
+    active: true
+
+  - id: text/html
+    term: HTML
+    alts: ['text/html']
     active: true
 
   - id: image/jpeg
@@ -9,24 +34,19 @@ terms:
     alts: ['image/jpeg','image/jpg','jpg']
     active: true
 
-  - id: image/tiff
-    term: TIFF
-    alts: ['image/tiff','image/tif','tif']
-    active: true
-
   - id: image/jp2
     term: JP2
     alts: ['image/jp2']
     active: true
 
-  - id: image/png
-    term: PNG
-    alts: ['image/png']
+  - id: audio/mpeg
+    term: MPEG
+    alts: ['audio/mpeg','audio/mp3','audio/mpeg3','mp3','MP3','mpeg3']
     active: true
 
-  - id: image/gif
-    term: GIF
-    alts: ['image/gif']
+  - id: audio/mp4
+    term: MP4
+    alts: ['audio/mp4']
     active: true
 
   - id: video/mp4
@@ -39,54 +59,19 @@ terms:
     alts: ['video/ogg']
     active: true
 
-  - id: video/vnd.avi
-    term: AVI
-    alts: ['video/vnd.avi','video/avi']
-    active: true
-
-  - id: audio/aac
-    term: AAC
-    alts: ['audio/aac']
-    active: true
-
-  - id: audio/mp4
-    term: MP4
-    alts: ['audio/mp4']
-    active: true
-
-  - id: audio/mpeg
-    term: MPEG
-    alts: ['audio/mpeg','audio/mp3','audio/mpeg3','mp3','MP3','mpeg3']
-    active: true
-
   - id: audio/ogg
     term: OGG
     alts: ['audio/ogg']
     active: true
 
-  - id: audio/aiff
-    term: AIFF
-    alts: ['audio/aiff']
+  - id: application/pdf
+    term: PDF
+    alts: ['pdf','application/pdf']
     active: true
 
-  - id: audio/webm
-    term: WEBM
-    alts: ['audio/webm']
-    active: true
-
-  - id: audio/wav
-    term: WAV
-    alts: ['audio/wav']
-    active: true
-
-  - id: text/csv
-    term: CSV
-    alts: ['text/csv']
-    active: true
-
-  - id: text/html
-    term: HTML
-    alts: ['text/html']
+  - id: image/png
+    term: PNG
+    alts: ['image/png']
     active: true
 
   - id: text/rtf
@@ -94,6 +79,22 @@ terms:
     alts: ['text/rtf']
     active: true
 
+  - id: image/tiff
+    term: TIFF
+    alts: ['image/tiff','image/tif','tif']
+    active: true
+
   - id: url
     term: URL
+    alts: ['url']
+    active: true
+
+  - id: audio/wav
+    term: WAV
+    alts: ['audio/wav']
+    active: true
+
+  - id: audio/webm
+    term: WEBM
+    alts: ['audio/webm']
     active: true


### PR DESCRIPTION
# Story
- format was not being saved correctly. The service was missing a few methods that were in the DL in order to make this happen
- extra non-blank fields were being added in the work form. now the field includes a blank option so that it doesn't just save extra pdf formats
- alphabetizes the formats in the dropdown
- removes duplicate MPEG & OGG, adds MOV

# Related
- #27 

# Screenshots / Video

<details>
<summary>format showing up correctly for imported work </summary>
<img width="791" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/406ed60e-c22c-46a2-8c01-2587e345b2d6">

</details>

<details>
<summary>new list of formats</summary>
<img width="593" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/210acd43-34d2-4e26-ad7a-a9aa2349fc2c">

</details>


# Notes