### PR TITLE
Date + Type rework

### DIFF
--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -14,8 +14,16 @@ class Etd < ActiveFedora::Base
   validates :level, presence: { message: 'Your work must have a level.' }
   validates :discipline, presence: { message: 'Your work must have a discipline.' }
   validates :degree_granting_institution, presence: { message: 'Your work must have a degree granting institution.' }
-  validates :year, presence: { message: 'Your work must have a four-digit year.' }
   # rubocop:disable Style/RegexpLiteral
+  validates :year,
+    presence: {
+      message: 'Your work must have a four-digit year.'
+      },
+    format: {
+      # regex matches only youtube & vimeo urls that are formatted as embed links.
+      with: /\A(19|20)\d{2}\z/,
+      message: "Error: must be a valid YouTube or Vimeo Embed URL."
+    }
   validates :video_embed,
             format: {
               # regex matches only youtube & vimeo urls that are formatted as embed links.

--- a/app/views/records/edit_fields/_year.html.erb
+++ b/app/views/records/edit_fields/_year.html.erb
@@ -1,2 +1,0 @@
-<%= f.input :year, collection: 1900..Time.zone.today.year+4, input_html: { class: 'form-control',
-    multiple: false, value: "#{ f.object.year }" } %>

--- a/config/authorities/types.yml
+++ b/config/authorities/types.yml
@@ -19,7 +19,5 @@ terms:
     term: Software
   - id: Sound
     term: Sound
-  - id: Still Image
-    term: Still Image
   - id: Text
     term: Text

--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -9,7 +9,7 @@ en:
   simple_form:
     hints:
       defaults:
-        year: 'The year in which the work was created. This should be a 4-digit number'
+        year: 'The year in which the work was created. This must be a 4-digit year, and begin with 19 or 20'
         degree: 'Name of the degree associated with the work as it appears within the work.'
         level: 'Level of education associated with the document.'
         discipline: 'Area of study of the intellectual content of the document. Usually this will be the name of a program or department.'


### PR DESCRIPTION
# Story
- makes date just use a validation that it is a 4 digit number beginning with 19 or 20 instead of a dropdown
- removes Still Image from Types
- updates the year help text to be more clear what years it is expecting

# Related
- #29 
- #48 

# Screenshots / Video

<details>
<summary>year field on etds</summary>
<img width="794" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/96fd69b1-adb6-4d03-b844-ecb3476f450a">

</details>

# Notes