### PR TITLE
make date created and identifier actually search with their links

### DIFF
--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -8,11 +8,11 @@
 <%= presenter.attribute_to_html(:access_right, html_dl: true) %>
 <%= presenter.attribute_to_html(:rights_notes, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:date_created, render_as: :faceted, search_field: 'date_created_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:date_created, render_as: :linked, html_dl: true, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:year, render_as: :faceted, search_field: 'year_tesim', html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
-<%= presenter.attribute_to_html(:identifier, render_as: :linked, search_field: 'identifier_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:identifier, render_as: :linked, html_dl: true, search_field: 'all_fields') %>
 <%= presenter.attribute_to_html(:related_url, render_as: :external_link, html_dl: true) %>
 <%= presenter.attribute_to_html(:source, html_dl: true) %>
 <%= presenter.attribute_to_html(:resource_type, render_as: :faceted, html_dl: true) %>

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -9,7 +9,7 @@
 <%= presenter.attribute_to_html(:rights_notes, html_dl: true) %>
 <%= presenter.attribute_to_html(:publisher, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_created, render_as: :linked, html_dl: true, search_field: 'all_fields') %>
-<%= presenter.attribute_to_html(:year, render_as: :faceted, search_field: 'year_tesim', html_dl: true) %>
+<%= presenter.attribute_to_html(:year, render_as: :linked, search_field: 'all_fields', html_dl: true) %>
 <%= presenter.attribute_to_html(:subject, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:language, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:identifier, render_as: :linked, html_dl: true, search_field: 'all_fields') %>


### PR DESCRIPTION
# Story
- links to search on work show page for date created, identifier, and year were broken
- make date created and identifier actually search with their links

# Related 
- https://github.com/scientist-softserv/atla-hyku/issues/24

# Expected Behavior Before Changes
- could not search from the links on the work show page for date created, identifier, and year

# Expected Behavior After Changes
- can not search from the links on the work show page for date created, identifier, and year

# Video
https://share.getcloudapp.com/P8u2J2QP

