### PR TITLE
Pdf files not showing in viewer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -22,7 +22,7 @@ GIT
 
 GIT
   remote: https://github.com/scientist-softserv/iiif_print.git
-  revision: 44d96c8e8e633ed56d286851648e9fbdf3feb880
+  revision: 8fdf56e151b5adb7e6aab1cd29d39b74554ed48a
   branch: main
   specs:
     iiif_print (1.0.0)
@@ -32,6 +32,7 @@ GIT
       nokogiri (>= 1.13.2)
       rails (~> 5.0)
       rdf-vocab (~> 3.0)
+      reform-rails (= 0.2.3)
 
 GIT
   remote: https://github.com/tawan/active-elastic-job.git

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -5,7 +5,7 @@
 class Etd < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: GenericWork
   )
 
   self.indexer = EtdIndexer

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -4,6 +4,9 @@
 #  `rails generate hyrax:work Etd`
 class Etd < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
+  include IiifPrint.model_configuration(
+    pdf_split_child_model: self
+  )
 
   self.indexer = EtdIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/models/paper_or_report.rb
+++ b/app/models/paper_or_report.rb
@@ -5,7 +5,7 @@
 class PaperOrReport < ActiveFedora::Base
   include ::Hyrax::WorkBehavior
   include IiifPrint.model_configuration(
-    pdf_split_child_model: self
+    pdf_split_child_model: GenericWork
   )
 
   self.indexer = PaperOrReportIndexer


### PR DESCRIPTION
# Coauthor
@kirkkwang 

# Story
- PDFs were not splitting correctly, which was causing them to not show up in the viewer for both Paper or Report & Etd worktypes.
- the generated derivative files need to be created as generic worktypes instead of as `self`

# Related
- #69 

# Expected Behavior Before Changes
- pdfs would not show up in the viewer for paper or report & etd worktypes

# Expected Behavior After Changes
- pdfs display in the viewer for paper or report & etd worktypes
- derivative files are created for each pdf page for paper or report & etd worktypes


# Screenshots / Video

<details>
<summary>successful etd work with pdf</summary>
<img width="1322" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/483cddc9-ff5b-499b-8118-0947ffe47213">
</details>
