### PR TITLE
Make format validate correctly

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -7,6 +7,7 @@ module Bulkrax
     # to add a custom property from outside of the import data
     def add_local
       parsed_metadata['year'] = parse_year(parsed_metadata['year']) if parsed_metadata['year']
+      parsed_metadata['format'] = parse_format(parsed_metadata['format']) if parsed_metadata['format']
     end
 
     def parse_year(src)
@@ -14,6 +15,16 @@ module Bulkrax
       valid = src.match?(/^(19|20)\d{2}$/)
       error_msg = %("#{src}" is not a 4 digit year.)
       valid ? src : (raise ::StandardError, error_msg)
+    end
+
+    def parse_format(src)
+      src.map do |format|
+        # will return nil if it doesn't match with any format label
+        label = Hyrax::FormatService.label_from_alt(format)
+        valid = label.present?
+        error_msg = %("#{format}" is not a valid type of format.)
+        valid ? label : (raise ::StandardError, error_msg)
+      end
     end
   end
 end

--- a/config/initializers/bulkrax.rb
+++ b/config/initializers/bulkrax.rb
@@ -136,7 +136,7 @@ if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true'
     # the config/authorities/ directory. For example, the :rights_statement property
     # is controlled by the active terms in config/authorities/rights_statements.yml
     # Default properties: 'rights_statement' and 'license'
-    config.qa_controlled_properties += ['types', 'resource_type', 'format', 'institution']
+    config.qa_controlled_properties += ['types', 'resource_type', 'institution']
   end
 
   Bulkrax::CreateRelationshipsJob.update_child_records_works_file_sets = true


### PR DESCRIPTION
# Story
Based on client feedback
<img width="969" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/b098a819-0f38-41c9-8d06-1bccd8416a81">

- https://github.com/scientist-softserv/atla-hyku/issues/27#issuecomment-1553691046

# Related
- https://github.com/scientist-softserv/atla-hyku/issues/27

# Expected Behavior Before Changes
You could import csvs that listed id of the format controlled vocab (for instance, application/pdf)

# Expected Behavior After Changes
You can add any alt for formats in csv imports (see list here https://github.com/scientist-softserv/atla-hyku/blob/main/config/authorities/formats.yml)

# Screenshots / Video

<details>
<summary>Error thrown with wrong type of format</summary>
<img width="1261" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/47b89b2a-4ea2-4617-81ab-66c69752519a">

</details>