### PR TITLE
Fix array with empty string bug

### DIFF
--- a/app/presenters/hyku/work_show_presenter.rb
+++ b/app/presenters/hyku/work_show_presenter.rb
@@ -73,7 +73,7 @@ module Hyku
     private
 
       def extract_video_embed_presence
-        solr_document[:video_embed_tesim].present?
+        solr_document[:video_embed_tesim]&.all?(&:present?)
       end
 
       def iiif_media?(presenter: representative_presenter)


### PR DESCRIPTION
# Story
CSV imports have an array with an empty string when there is a blank value in the cell. The method that determines wheter the embedded video or the uv displays needs to account for that on the show pages. 

# Related
- #88 
