### PR TITLE
department help text should only apply to etds

### DIFF
--- a/config/locales/etd.en.yml
+++ b/config/locales/etd.en.yml
@@ -16,9 +16,9 @@ en:
         degree_granting_institution: 'Institution granting the degree associated with the work.'
         advisor: 'Name of thesis/dissertation advisor or committee chair.'
         committee_member: 'Name of committee member/s.'
-        department: 'Name of the department or unit within the institution granting the degree.'
       etd:
         subject: "Choose headings or index terms describing what the work is about from the our <a href='https://docs.google.com/spreadsheets/d/15Od1lx5AYsOsc63w3KX7a9nFt2TsAAH51cCdlVARuQ0/edit?usp=sharing'>subject</a> list. If your terms are missing from the list use <a href='https://fast.oclc.org/searchfast/'>FAST subject headings</a>. For additional religion and theology terms that should be added to our list use <a href='https://forms.gle/TGhEKCSyBwJjnCCc8'>this form.</a>"
+        department: 'Name of the department or unit within the institution granting the degree.'
     labels:
       defaults:
         bibliographic_citation: 'Bibliographic citation'


### PR DESCRIPTION
# Story
The help text for department should only be set for etds - not for the user accounts

Refs #90 