### PR TITLE
Remap dc type so it points to types in the oai_dc feed

### DIFF
--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -77,6 +77,6 @@ class SolrDocument
     rights: 'rights_statement_tesim',
     subject: 'subject_tesim',
     title: 'title_tesim',
-    type: 'human_readable_type_tesim'
+    type: 'types_tesim'
   )
 end


### PR DESCRIPTION
# Story
dc:type maps to work type as the default in hyku for `oai_dc`. I do not think this needs to be the case.

In the oai gem, [it says that the field_semantics hash is used to assign the values for the `oai_dc` feed](https://github.com/projectblacklight/blacklight_oai_provider/blob/69795b06cc37150386b6d9732be027d200412598/README.md?plain=1#L107)

I checked in both [Hyrax](https://github.com/search?q=repo%3Asamvera%2Fhyrax%20field_semantics&type=code) & [Blacklight](https://github.com/search?q=repo%3Aprojectblacklight%2Fblacklight%20field_semantics&type=code), and this `field_semantics` hash doesn't seem to be used anywhere else that is not related to the blacklight oai gem. I also saw that the `field_semantics` hash was added to the `solr_document.rb` just 4 years ago, [in a commit by rob to add the oai gem to hyku](https://github.com/samvera/hyku/commit/c60c85061781594afe739c2eba50650554521cd9). So i think it is hopefully safe to change, but let me know if this is ill advised. 

# Related
- #10 

# Expected Behavior Before Changes
dc:type in the oai feed was mapping to work type

# Expected Behavior After Changes
dc:type maps to atla's "types" field

# Screenshots / Video

<details>
<summary>"Dataset" is one of the "Types" - the only work types are Etd, Collection, Generic Work, and Paper or Report</summary>
<img width="573" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/73361970/4cff2a62-9535-4d2c-a9fe-602a8e00081e">

</details>
