### PR TITLE
Citations

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -132,11 +132,14 @@ Rails/HasManyOrHasOneDependent:
   Exclude:
     - 'app/models/endpoint.rb'
 
-# Offense count: 5
+# Offense count: 7
 Rails/OutputSafety:
   Exclude:
     - 'app/forms/hyrax/forms/admin/appearance.rb'
     - 'app/helpers/blacklight/catalog_helper_behavior.rb'
+    - 'app/helpers/hyrax/citations_behaviors/formatters/apa_formatter.rb'
+    - 'app/helpers/hyrax/citations_behaviors/formatters/chicago_formatter.rb'
+    - 'app/helpers/hyrax/citations_behaviors/formatters/mla_formatter.rb'
 
 # Offense count: 1
 # Cop supports --auto-correct.

--- a/app/assets/stylesheets/atla-overrides.scss
+++ b/app/assets/stylesheets/atla-overrides.scss
@@ -56,6 +56,24 @@ div.facets h3 {font-size: 1em;}
 /* admin dashboard available works ETD all caps*/
 .dashboard label[for="input-Etd"] {text-transform: uppercase;}
 
+/* citations style */
+button.btn.btn-default.btn-block.citations-button.center-block {margin-top: 1em;}
+.mla-citation, .apa-citation, .chicago-citation {
+    line-height: 1.25em;
+    display: inline-block;
+    width: 100%;
+    font-size:0.875em;
+}
+div#collapse-citations{text-align:left;overflow-wrap: break-word;}
+div#collapse-citations h4 {font-size:1em;}
+div#collapse-citations p {font-size:0.85em;}
+button.btn.btn-default.btn-block.citations-button.center-block:hover, button.btn.btn-default.btn-block.citations-button.center-block:focus{
+     background-color:#337ab7;
+     border-color: #204d75;
+     color:white;
+}
+
+
 
 @media only screen and (min-width: 768px) {
      .hyc-banner .hyc-title h1 {margin-bottom: 0em;}

--- a/app/helpers/hyrax/citation_behaviors/common_behavior.rb
+++ b/app/helpers/hyrax/citation_behaviors/common_behavior.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module CommonBehavior
+      def persistent_url(work); end
+
+      def clean_end_punctuation(text)
+        return text[0, text.length - 1] if text && ([".", ",", ":", ";", "/"].include? text[-1, 1])
+        text
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/formatters.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters.rb
@@ -1,0 +1,30 @@
+# Hyrax Override: Improve Citations Format
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class BaseFormatter
+        include Hyrax::CitationsBehaviors::CommonBehavior
+        include Hyrax::CitationsBehaviors::NameBehavior
+
+        attr_reader :view_context
+
+        def initialize(view_context)
+          @view_context = view_context
+        end
+
+        # Hyrax Override: Adds new functionality for citations
+        def add_link_to_original(work)
+          persistent_url(work).to_s
+        end
+        # end
+      end
+
+      autoload :ApaFormatter, 'hyrax/citations_behaviors/formatters/apa_formatter'
+      autoload :ChicagoFormatter, 'hyrax/citations_behaviors/formatters/chicago_formatter'
+      autoload :MlaFormatter, 'hyrax/citations_behaviors/formatters/mla_formatter'
+      autoload :OpenUrlFormatter, 'hyrax/citations_behaviors/formatters/open_url_formatter'
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/apa_formatter.rb
@@ -1,0 +1,94 @@
+# Hyrax Override: Improve Format of Citations
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class ApaFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+          text += authors_text_for(work)
+          text += pub_date_text_for(work)
+          text += add_title_text_for(work)
+          # Hyrax Override: adds addtl content for citation
+          text += " <span class='citation-link'>#{add_link_to_original(work)}</span>"
+          # end
+          text.html_safe
+        end
+
+        private
+
+          def authors_text_for(work)
+            # setup formatted author list
+            authors_list = author_list(work).reject(&:blank?)
+            author_text = format_authors(authors_list)
+            if author_text.blank?
+              author_text
+            else
+              "<span class=\"citation-author\">#{author_text}</span> "
+            end
+          end
+
+        public
+
+        def format_authors(authors_list = [])
+          return '' if authors_list.blank?
+          authors_list = Array.wrap(authors_list).collect { |name| name.strip }
+          text = ''
+          text += convert_to_initials(authors_list.first) if authors_list.first
+          authors_list[1..-1].each do |author|
+            text += if author == authors_list.last
+                      ", &amp; #{convert_to_initials(author)}"
+                    else
+                      ", #{convert_to_initials(author)}"
+                    end
+          end
+          text += "." unless text.end_with?(".")
+          text
+        end
+
+        private
+
+          def pub_date_text_for(work)
+            # Get Pub Date
+            pub_date = setup_pub_date(work)
+            format_date(pub_date)
+          end
+
+          def add_title_text_for(work)
+            # setup title info
+            title_info = setup_title_info(work)
+            format_title(title_info)
+          end
+
+          def add_publisher_text_for(work)
+            # Publisher info
+            pub_info = clean_end_punctuation(setup_pub_info(work))
+            if pub_info.blank?
+              ''
+            else
+              pub_info + "."
+            end
+          end
+
+          def convert_to_initials(name)
+            name = name.split(" ")
+            name.map { |n| n.equal?(name.last) ? n.capitalize : n[0].capitalize }.join(". ")
+          end
+
+        public
+
+        def format_date(pub_date)
+          pub_date.blank? ? "" : "(" + pub_date + "). "
+        end
+
+        def format_title(title_info)
+          title_info.nil? ? "" : "<i class=\"citation-title\">#{title_info}</i> "
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/formatters/apa_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/apa_formatter.rb
@@ -36,7 +36,7 @@ module Hyrax
 
         def format_authors(authors_list = [])
           return '' if authors_list.blank?
-          authors_list = Array.wrap(authors_list).collect { |name| name.strip }
+          authors_list = Array.wrap(authors_list).collect(&:strip)
           text = ''
           text += convert_to_initials(authors_list.first) if authors_list.first
           authors_list[1..-1].each do |author|

--- a/app/helpers/hyrax/citation_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/chicago_formatter.rb
@@ -16,7 +16,7 @@ module Hyrax
           text = "<span class=\"citation-author\">#{text}</span>" if text.present?
           text += format_title(work.to_s)
           pub_info = setup_pub_info(work, false)
-          text += " #{whitewash(pub_info)}." unless pub_info.blank?
+          text += " #{whitewash(pub_info)}." if pub_info.present?
           pub_date = setup_pub_date(work)
           text += " #{whitewash(pub_date)}." unless pub_date.nil?
           text += "  <span class='citation-link'>#{add_link_to_original(work)}</span>"

--- a/app/helpers/hyrax/citation_behaviors/formatters/chicago_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/chicago_formatter.rb
@@ -1,0 +1,64 @@
+# Hyrax Override: Improve Citations Format
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class ChicagoFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+        def format(work)
+          text = ""
+
+          # setup formatted author list
+          authors_list = all_authors(work)
+          text += format_authors(authors_list)
+          text = "<span class=\"citation-author\">#{text}</span>" if text.present?
+          text += format_title(work.to_s)
+          pub_info = setup_pub_info(work, false)
+          text += " #{whitewash(pub_info)}." unless pub_info.blank?
+          pub_date = setup_pub_date(work)
+          text += " #{whitewash(pub_date)}." unless pub_date.nil?
+          text += "  <span class='citation-link'>#{add_link_to_original(work)}</span>"
+          # end
+
+          text.html_safe
+        end
+
+        def format_authors(authors_list = [])
+          return '' if authors_list.blank?
+          text = ''
+          text += authors_list.first if authors_list.first
+          authors_list[1..6].each_with_index do |author, index|
+            text += if index + 2 == authors_list.length # we've skipped the first author
+                      ", and #{author}."
+                    else
+                      ", #{author}"
+                    end
+          end
+          text += " et al." if authors_list.length > 7
+          # if for some reason the first author ended with a comma
+          text = text.gsub(',,', ',')
+          text += "." unless text.end_with?(".")
+          whitewash(text)
+        end
+
+        def format_date(pub_date); end
+
+        def format_title(title_info)
+          return "" if title_info.blank?
+          title_text = chicago_citation_title(title_info)
+          title_text += '.' unless title_text.end_with?(".")
+          title_text = whitewash(title_text)
+          " <i class=\"citation-title\">#{title_text}</i>"
+        end
+
+        private
+
+          def whitewash(text)
+            Loofah.fragment(text.to_s).scrub!(:whitewash).to_s
+          end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/mla_formatter.rb
@@ -1,0 +1,75 @@
+# Hyrax Override: Improve Citations Format
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module Formatters
+      class MlaFormatter < BaseFormatter
+        include Hyrax::CitationsBehaviors::PublicationBehavior
+        include Hyrax::CitationsBehaviors::TitleBehavior
+
+        def format(work)
+          text = ''
+
+          # setup formatted author list
+          authors = author_list(work).reject(&:blank?)
+          text += "<span class=\"citation-author\">#{format_authors(authors)}</span>"
+          # setup title
+          title_info = setup_title_info(work)
+          text += format_title(title_info)
+
+          # Hyrax Override: adds contributor
+          text += " #{work.contributor.join(', ')}." unless work.contributor.blank?
+
+          # Publication
+          pub_info = clean_end_punctuation(setup_pub_info(work, true))
+          text += "<span class=\"citation-publication-info\">#{pub_info}. </span>" unless pub_info.blank?
+          # text += (pub_info + ".") if pub_info.present?
+
+          # Hyrax Override: adds addtl content for citation
+          # text += add_link_to_original(work)
+          text += " <span class='citation-link'>#{add_link_to_original(work)}</span>"
+          # end
+
+          text.html_safe
+        end
+
+        def format_authors(authors_list = [])
+          return "" if authors_list.blank?
+          authors_list = Array.wrap(authors_list)
+          text = concatenate_authors_from(authors_list)
+          if text.present?
+            text += "." unless text.end_with?(".")
+            text += " "
+          end
+          text
+        end
+
+        def concatenate_authors_from(authors_list)
+          text = ''
+          text += authors_list.first
+          if authors_list.length > 1
+            if authors_list.length < 4
+              authors_list[1...-1].each do |author|
+                text += ", #{author}"
+              end
+              text += ", and #{authors_list.last}"
+            else
+              text += ", et al"
+            end
+          end
+          text
+        end
+        private :concatenate_authors_from
+
+        def format_date(pub_date)
+          " #{pub_date.join(', ')}."
+        end
+
+        def format_title(title_info)
+          title_info.blank? ? "" : "<i class=\"citation-title\">#{mla_citation_title(title_info)}</i> "
+        end
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/formatters/mla_formatter.rb
+++ b/app/helpers/hyrax/citation_behaviors/formatters/mla_formatter.rb
@@ -19,11 +19,11 @@ module Hyrax
           text += format_title(title_info)
 
           # Hyrax Override: adds contributor
-          text += " #{work.contributor.join(', ')}." unless work.contributor.blank?
+          text += " #{work.contributor.join(', ')}." if work.contributor.present?
 
           # Publication
           pub_info = clean_end_punctuation(setup_pub_info(work, true))
-          text += "<span class=\"citation-publication-info\">#{pub_info}. </span>" unless pub_info.blank?
+          text += "<span class=\"citation-publication-info\">#{pub_info}. </span>" if pub_info.present?
           # text += (pub_info + ".") if pub_info.present?
 
           # Hyrax Override: adds addtl content for citation

--- a/app/helpers/hyrax/citation_behaviors/name_behavior.rb
+++ b/app/helpers/hyrax/citation_behaviors/name_behavior.rb
@@ -1,0 +1,53 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module NameBehavior
+      include Hyrax::CitationsBehaviors::CommonBehavior
+      # return all unique authors with end punctuation removed
+      def author_list(work)
+        all_authors(work) { |author| clean_end_punctuation(CGI.escapeHTML(author)) }
+      end
+
+      # return all unique authors of a work or nil if none
+      def all_authors(work, &block)
+        authors = work.creator.uniq.compact
+        block_given? ? authors.map(&block) : authors
+      end
+
+      def given_name_first(name)
+        name = clean_end_punctuation(name)
+        return name unless name.include?(',')
+        temp_name = name.split(/,\s*/)
+        temp_name.last + " " + temp_name.first
+      end
+
+      def surname_first(name)
+        name = name.join('') if name.is_a? Array
+        # make sure we handle "Cher" correctly
+        return name if name.include?(',')
+        name_segments = name.split(' ')
+        given_name = name_segments.first
+        surnames = name_segments[1..-1]
+        if surnames
+          "#{surnames.join(' ')}, #{given_name}"
+        else
+          given_name
+        end
+      end
+
+      def abbreviate_name(name)
+        abbreviated_name = ''
+        name = name.join('') if name.is_a? Array
+
+        # make sure we handle "Cher" correctly
+        return name unless name.include?(' ') || name.include?(',')
+        name = surname_first(name)
+        name_segments = name.split(/,\s*/)
+        abbreviated_name += name_segments.first
+        abbreviated_name += ", #{name_segments.last.first}" if name_segments[1]
+        abbreviated_name + "."
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/publication_behavior.rb
+++ b/app/helpers/hyrax/citation_behaviors/publication_behavior.rb
@@ -1,0 +1,48 @@
+# Hyrax Override: Improve Citations Format
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module PublicationBehavior
+      include Hyrax::CitationsBehaviors::CommonBehavior
+      def setup_pub_date(work)
+        first_date = work.date_created.first if work.date_created
+        if first_date.present?
+          first_date = CGI.escapeHTML(first_date)
+          date_value = first_date.gsub(/[^0-9|n\.d\.]/, "")[0, 4]
+          return nil if date_value.nil?
+        end
+        clean_end_punctuation(date_value) if date_value
+      end
+
+      # @param [Hyrax::WorkShowPresenter] work_presenter
+      def setup_pub_place(work_presenter)
+        work_presenter.based_near_label&.first
+      end
+
+      def setup_pub_publisher(work)
+        work.publisher&.first
+      end
+
+      def setup_pub_info(work, include_date = false)
+        pub_info = ""
+
+        if (place = setup_pub_place(work))
+          pub_info += CGI.escapeHTML(place)
+        end
+
+        if (publisher = setup_pub_publisher(work))
+          # Hyrax Override: format was wrong
+          # ':' should only be added if there is previous info
+          pub_info += ":" unless pub_info.empty?
+          pub_info += " #{CGI.escapeHTML(publisher)}"
+        end
+
+        pub_date = include_date ? setup_pub_date(work) : nil
+        pub_info += ". #{pub_date}" unless pub_date.nil?
+
+        pub_info.strip.presence
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citation_behaviors/title_behavior.rb
+++ b/app/helpers/hyrax/citation_behaviors/title_behavior.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehaviors
+    module TitleBehavior
+      include Hyrax::CitationsBehaviors::CommonBehavior
+
+      TITLE_NOCAPS = ["a", "an", "and", "but", "by", "for", "it", "of", "the", "to", "with"].freeze
+      EXPANDED_NOCAPS = TITLE_NOCAPS + ["about", "across", "before", "without"]
+
+      def chicago_citation_title(title_text)
+        process_title_parts(title_text) do |w, index|
+          if (index.zero? && w.casecmp(w).zero?) || (w.length > 1 && w.casecmp(w).zero? && !EXPANDED_NOCAPS.include?(w))
+            # the split("-") will handle the capitalization of hyphenated words
+            w.split("-").map!(&:capitalize).join("-")
+          else
+            w
+          end
+        end
+      end
+
+      def mla_citation_title(title_text)
+        process_title_parts(title_text) do |w|
+          if TITLE_NOCAPS.include? w
+            w
+          else
+            w.capitalize
+          end
+        end
+      end
+
+      def process_title_parts(title_text, &block)
+        if block_given?
+          title_text.split(" ").collect.with_index(&block).join(" ")
+        else
+          title_text
+        end
+      end
+
+      def setup_title_info(work)
+        text = ''
+        title = work.to_s
+        if title.present?
+          title = CGI.escapeHTML(title)
+          title_info = clean_end_punctuation(title.strip)
+          text += title_info
+        end
+
+        return nil if text.strip.blank?
+        clean_end_punctuation(text.strip) + "."
+      end
+    end
+  end
+end

--- a/app/helpers/hyrax/citations_behavior.rb
+++ b/app/helpers/hyrax/citations_behavior.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+module Hyrax
+  module CitationsBehavior
+    include Hyrax::CitationsBehaviors::CommonBehavior
+    include Hyrax::CitationsBehaviors::Formatters
+    include Hyrax::CitationsBehaviors::PublicationBehavior
+    include Hyrax::CitationsBehaviors::NameBehavior
+    include Hyrax::CitationsBehaviors::TitleBehavior
+
+    def export_as_apa_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::ApaFormatter.new(self).format(work)
+    end
+
+    def export_as_chicago_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::ChicagoFormatter.new(self).format(work)
+    end
+
+    def export_as_mla_citation(work)
+      Hyrax::CitationsBehaviors::Formatters::MlaFormatter.new(self).format(work)
+    end
+
+    # MIME type: 'application/x-openurl-ctx-kev'
+    def export_as_openurl_ctx_kev(work)
+      Hyrax::CitationsBehaviors::Formatters::OpenUrlFormatter.new(self).format(work)
+    end
+  end
+end

--- a/app/views/hyrax/base/_citations.html.erb
+++ b/app/views/hyrax/base/_citations.html.erb
@@ -1,0 +1,35 @@
+<button
+  class="btn btn-default btn-block citations-button center-block"
+  data-toggle="collapse"
+  href="#collapse-citations"
+  role="button"
+  aria-expanded="false"
+  aria-controls="collapse-citations"
+>
+  <%= t('.header') %>
+</button>
+         
+<div id="collapse-citations" class="collapse">
+  <br/>
+  <h4>MLA citation style (9th ed.)</h4>
+  <span class="mla-citation"><%= export_as_mla_citation(@presenter) %>
+  <%= request.original_url.sub(/^https?\:\/\/(www.)?/,'') %>.
+  </span>
+  <br /><br />
+
+  <h4>APA citation style (7th ed.)</h4>
+  <span class="apa-citation"><%= export_as_apa_citation(@presenter) %>
+   <%= request.original_url %>
+  </span>
+  <br /><br />
+
+  <h4>Chicago citation style (CMOS 17, author-date)</h4>
+  <span class="chicago-citation"><%= export_as_chicago_citation(@presenter) %>
+  <%= request.original_url %>.</span>
+  <br /><br />
+
+  <p>
+    <strong>Note:</strong>
+    These citations are programmatically generated and may be incomplete.
+  </p>
+</div>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -346,7 +346,7 @@ en:
     background_attribution_html: ""
     base:
       citations:
-        header: "Citations:"
+        header: "Cite this item"
       form_child_work_relationships:
         actions:
           remove: Remove from this work


### PR DESCRIPTION
# Story
We wanted our citation tool to be like we have it in the digital library. To do this I grabbed all the related citation files from the PALS project and added them to ours. I adjusted Citations to say Cite this item and added some CSS to style them.

I added to the rubocop file to match what PALS had as well - not sure if this was needed or not.

Running rubocop showed 3 issues "Rails/OutputSafety: Tagging a string as html safe may be a security risk. text.html_safe" but since this is the same code that is in PALS I think it must be okay.

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes