### PR TITLE
added tenant logos using directory image to splash page

### DIFF
--- a/app/controllers/splash_controller.rb
+++ b/app/controllers/splash_controller.rb
@@ -2,14 +2,15 @@
 
 class SplashController < ProprietorController
   def index
-      @accounts = Account.where('is_public = ?', true).order(cname: :asc)
-      @images = []
-      @alt_text = []
-      @accounts.map do |account|
-        Apartment::Tenant.switch(account.tenant) do
-          @images << Site.instance&.directory_image&.url(:medium) || "https://via.placeholder.com/400?text=#{account.cname}"
-          @alt_text << Site.instance || account.cname
-        end
+    @accounts = Account.where('is_public = ?', true).order(cname: :asc)
+    @images = []
+    @alt_text = []
+    @accounts.map do |account|
+      Apartment::Tenant.switch(account.tenant) do
+        @images << Site.instance&.directory_image&.url(:medium) ||
+          "https://via.placeholder.com/400?text=#{account.cname}"
+        @alt_text << Site.instance || account.cname
       end
     end
+  end
 end

--- a/app/controllers/splash_controller.rb
+++ b/app/controllers/splash_controller.rb
@@ -1,5 +1,15 @@
 # frozen_string_literal: true
 
 class SplashController < ProprietorController
-  def index; end
+  def index
+      @accounts = Account.where('is_public = ?', true).order(cname: :asc)
+      @images = []
+      @alt_text = []
+      @accounts.map do |account|
+        Apartment::Tenant.switch(account.tenant) do
+          @images << Site.instance&.directory_image&.url(:medium) || "https://via.placeholder.com/400?text=#{account.cname}"
+          @alt_text << Site.instance || account.cname
+        end
+      end
+    end
 end

--- a/app/views/splash/index.html.erb
+++ b/app/views/splash/index.html.erb
@@ -10,25 +10,18 @@
     </div>
 
     <div class="col-sm-6 right-side">
-
          <h2>Browse our partner repositories:</h2>
-         <div class="row home-logo-grid">
-             <div class="col-xs-6 col-sm-4">
-                  <%= link_to "//#{host_for('rim')}" do %>
-                         <%= image_tag("home-logos/rim_atla.png", class: "tenant-logo", alt: "RIM") %>
+           <div class="row home-logo-grid">
+                  <% @accounts.each_with_index do |account, i| %>
+                  <div class="col-xs-6 col-sm-4">
+                    <% if @images[i].present? && !@images[i].match(/placeholder/) %>
+                      <%= link_to "//#{account.cname}" do %>
+                        <%= image_tag @images[i], class: 'logo-image' %>
+                      <% end %>
+                    <% end %>
+                     </div>
                   <% end %>
-             </div>
-             <div class="col-xs-6 col-sm-4">
-                  <%= link_to "//#{host_for('ctschicago')}" do %>
-                    <%= image_tag("home-logos/ctschicago.png", class: "tenant-logo", alt: "CTS") %>
-                   <% end %>
-             </div>
-             <div class="col-xs-6 col-sm-4">
-                  <%= link_to "//#{host_for('ost')}" do %>
-                    <%= image_tag("home-logos/ost.png", class: "tenant-logo", alt: "OST") %>
-                  <% end %>
-             </div>
-          </div>
+           </div>
           <%= link_to "//#{host_for('shared-search')}/catalog" do %>
                <button class="shared-search">Search All Repositories</button>
           <% end %>

--- a/app/views/themes/shared_repository/splash/_index.html.erb
+++ b/app/views/themes/shared_repository/splash/_index.html.erb
@@ -14,19 +14,19 @@
               <h2>Browse our partner repositories:</h2>
               <div class="row home-logo-grid">
                   <div class="col-xs-6 col-sm-4">
-                        <%= link_to "//#{host_for('rim')}" do %>
-                              <%= image_tag("home-logos/rim_atla.png", class: "tenant-logo", alt: "RIM") %>
-                         <% end %>
-                  </div>
-                  <div class="col-xs-6 col-sm-4">
                        <%= link_to "//#{host_for('ctschicago')}" do %>
-                         <%= image_tag("home-logos/ctschicago.png", class: "tenant-logo", alt: "CTS") %>
+                         <%= image_tag("home-logos/ctschicago.png", class: "tenant-logo", alt: "CTSChicago") %>
                          <% end %>
                   </div>
                   <div class="col-xs-6 col-sm-4">
                        <%= link_to "//#{host_for('ost')}" do %>
                          <%= image_tag("home-logos/ost.png", class: "tenant-logo", alt: "OST") %>
                          <% end %>
+                  </div>
+                  <div class="col-xs-6 col-sm-4">
+                    <%= link_to "//#{host_for('rim')}" do %>
+                         <%= image_tag("home-logos/rim_atla.png", class: "tenant-logo", alt: "RIM") %>
+                    <% end %>
                   </div>
              </div>
           </div>


### PR DESCRIPTION
# Story
Added tenant logos using the tenant directory image to splash. Was not able to do the same for the shared search splash which was set up to look similar, so rearranged to match a-z order that app splash will have

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes