### PR TITLE
Use model for required fields

### DIFF
--- a/app/models/concerns/bulkrax/has_local_processing.rb
+++ b/app/models/concerns/bulkrax/has_local_processing.rb
@@ -10,8 +10,18 @@ module Bulkrax
       parsed_metadata['format'] = parse_format(parsed_metadata['format']) if parsed_metadata['format']
     end
 
+    def form_class
+      return false unless parsed_metadata['model'].present?
+      @form_class ||= "Hyrax::#{parsed_metadata['model']}Form".constantize
+    end
+
+    def validate?(attribute)
+      form_class.required_fields.include?(attribute)
+    end
+
     def parse_year(src)
       src = src.strip.chomp
+      return src unless validate?(:year)
       valid = src.match?(/^(19|20)\d{2}$/)
       error_msg = %("#{src}" is not a 4 digit year.)
       valid ? src : (raise ::StandardError, error_msg)
@@ -21,9 +31,12 @@ module Bulkrax
       src.map do |format|
         # will return nil if it doesn't match with any format label
         label = Hyrax::FormatService.label_from_alt(format)
-        valid = label.present?
-        error_msg = %("#{format}" is not a valid type of format.)
-        valid ? label : (raise ::StandardError, error_msg)
+        if validate?(:format)
+          valid = label.present?
+          error_msg = %("#{format}" is not a valid type of format.)
+          raise(::StandardError, error_msg) unless valid
+        end
+        label
       end
     end
   end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   end
 
   def is_admin
-    has_role? :admin || has_role? :admin, Site.instance
+    has_role?(:admin) || has_role?(:admin, Site.instance)
   end
 
   def is_superadmin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,7 +37,7 @@ class User < ApplicationRecord
   end
 
   def is_admin
-    has_role? :admin
+    has_role? :admin || has_role? :admin, Site.instance
   end
 
   def is_superadmin

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -36,6 +36,10 @@ class User < ApplicationRecord
     email
   end
 
+  def is_admin
+    has_role? :admin
+  end
+
   def is_superadmin
     has_role? :superadmin
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,12 +6,12 @@ Rails.application.routes.draw do
 
   concern :iiif_search, BlacklightIiifSearch::Routes.new
   concern :oai_provider, BlacklightOaiProvider::Routes.new
-  
+
   mount Hyrax::IiifAv::Engine, at: '/'
   mount Riiif::Engine => 'images', as: :riiif if Hyrax.config.iiif_image_server?
 
-  authenticate :user, lambda { |u| u.is_superadmin } do
-    mount Sidekiq::Web => '/sidekiq'
+  authenticate :user, lambda { |u| u.is_superadmin || u.is_admin } do
+    mount Sidekiq::Web => '/jobs'
   end
 
   if ActiveModel::Type::Boolean.new.cast(ENV.fetch('HYKU_MULTITENANT', false))

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -134,6 +134,9 @@ services:
 
   web:
     <<: *app
+    # Uncomment command to access container with out starting Rails. Useful for debugging
+    # command: sleep infinity
+    # command: sh -l -c "bundle && bundle exec rails s -b 0.0.0.0"
     environment:
       - VIRTUAL_PORT=3000
       - VIRTUAL_HOST=.hyku.test

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -159,7 +159,7 @@ services:
         condition: service_started
       initialize_app:
         condition: service_completed_successfully
-    expose:
+    ports:
       - 3000
 
   worker:


### PR DESCRIPTION
# Story

#130 

# Expected Behavior Before Changes

Any model with out a year was throwing an error

# Expected Behavior After Changes

Only throw an error on the year if the year is required

# Notes

Asking Christi this question:
- We validate the format and year fields. If the field is required on a work type and it does not match the format we through an error. What do we do if it is not required? Do we make it blank or do we still throw an error on that records import?