### PR TITLE
Fix broken contact form and negative captcha

### DIFF
--- a/app/controllers/hyrax/contact_form_controller.rb
+++ b/app/controllers/hyrax/contact_form_controller.rb
@@ -14,6 +14,7 @@ module Hyrax
     include Blacklight::SearchHelper
     include Blacklight::AccessControls::Catalog
     layout 'homepage'
+    before_action :build_contact_form
     # OVERRIDE: Adding inject theme views method for theming
     around_action :inject_theme_views
     before_action :setup_negative_captcha, only: %i[new create]
@@ -44,7 +45,7 @@ module Hyrax
       # OVERRIDE: Hyrax 3.4.0 add @featured_collection_list
       @featured_collection_list = FeaturedCollectionList.new
       @announcement_text = ContentBlock.for(:announcement)
-    end
+        end
 
     def create
       # not spam, form is valid, and captcha is valid
@@ -77,6 +78,15 @@ module Hyrax
     def after_deliver; end
 
     private
+
+      def build_contact_form
+        @contact_form = model_class.new(contact_form_params)
+      end
+
+      def contact_form_params
+        return {} unless params.key?(:contact_form)
+        params.require(:contact_form).permit(:contact_method, :category, :name, :email, :subject, :message)
+      end
 
       # OVERRIDE: return collections for theming
       def collections(rows: 6)


### PR DESCRIPTION
# Story
compared to the hyrax & hyku contact form, code in `contact_form_controller`, some seemingly crucial methods were missing that was causing the form to display an error page. namely, the `:build_contact_form` method and before action. This should also fix the negative captcha issue

# Related
- https://github.com/scientist-softserv/atla-hyku/issues/19

# Video
https://share.getcloudapp.com/KouEPjEx

# Expected Behavior Before Changes
- contact form page did not load

# Expected Behavior After Changes
- contact form page loads
- user is able to submit the form without errors. 
(unable to test on mailtrap, but it works locally)