### PR TITLE
Inviting existing users fails

### DIFF
--- a/app/controllers/hyku/invitations_controller.rb
+++ b/app/controllers/hyku/invitations_controller.rb
@@ -14,6 +14,7 @@ module Hyku
       authorize! :grant_admin_role, User if params[:user][:role] == ::RolesService::ADMIN_ROLE
       self.resource = User.find_by(email: params[:user][:email]) || invite_resource
 
+      resource.add_default_group_membership!
       resource.add_role(params[:user][:role], Site.instance) if params[:user][:role].present?
 
       yield resource if block_given?

--- a/spec/controllers/hyku/invitations_controller_spec.rb
+++ b/spec/controllers/hyku/invitations_controller_spec.rb
@@ -31,5 +31,31 @@ RSpec.describe Hyku::InvitationsController, type: :controller do
       expect(response).to redirect_to Hyrax::Engine.routes.url_helpers.admin_users_path(locale: 'en')
       expect(flash[:notice]).to eq 'An invitation email has been sent to user@guest.org.'
     end
+
+    context 'when user already exists' do
+      let(:user) { create(:user) }
+
+      # Mimic the state of a user who is only active in other tenants;
+      # i.e. a user who has no roles in this tenant
+      before do
+        user.roles.destroy_all
+      end
+
+      it 'adds the user to the registered group' do
+        expect(user.roles).to be_empty
+        expect(user.groups).to be_empty
+
+        post :create, params: {
+          user: {
+            email: user.email,
+            role: ''
+          }
+        }
+
+        user.reload
+        expect(user.roles).not_to be_empty
+        expect(user.groups).to eq([Ability.registered_group_name])
+      end
+    end
   end
 end


### PR DESCRIPTION
Ref 
- https://github.com/scientist-softserv/palni-palci/issues/813 
- https://github.com/samvera/hyku/pull/2025 (`cherry-pick` source) 
- https://github.com/scientist-softserv/palni-palci/pull/856 

# Story 

Trying to add a user active in other repositories to another tenant does not return any error but does not add the user. 

Changes proposed in this pull request:
* Always add invited users to the tenant's Registered Users group 

# Acceptance Criteria 

- [ ] Invited users are always added to the Registered Users group  

# Testing Instructions 

1. Login as a super admin 
2. Create a new tenant (e.g. `Tenant A`)
3. Navigate to `Tenant A` > Dashboard > Manage Users 
4. Invite a new user who does not already exist in the **application** (i.e. across all tenants, not just one) 
5. Verify that the new user gets added to the Registered Users group in `Tenant A` 
6. Create a new tenant (e.g. `Tenant B`) 
7. Navigate to `Tenant B` > Dashboard > Manage Users 
8. Invite the same user from Step 4. Do not give it any individual roles in the invite form 
9. Verify that the user gets added to the Registered Users group in `Tenant B`

# Notes

The primary issue here is that invited users who already have an account (i.e. an instance of `User` in the database) were not being added to the tenant's Registered Users group. This meant that, if a user was invited with no specific roles, they simply wouldn't show up in the tenant at all. 