### PR TITLE
🐛 Hide PDF form fields on descriptions tab

### DIFF
--- a/app/views/records/edit_fields/_default.html.erb
+++ b/app/views/records/edit_fields/_default.html.erb
@@ -1,0 +1,8 @@
+<%# OVERRIDE: HydraEditor 5.0.5 to support hidden fields %>
+<% return if f.object.try(:hidden?, key) %>
+
+<% if f.object.multiple? key %>
+  <%= f.input key, as: :multi_value, input_html: { class: 'form-control' }, required: f.object.required?(key) %>
+<% else %>
+  <%= f.input key, required: f.object.required?(key) %>
+<% end %>


### PR DESCRIPTION
# Story

## 🐛 Hide PDF form fields on descriptions tab

2f88bc3faa864dc560832573a7886dba5ba05db5

This commit will hide the PDF form fields on the descriptions tab.  The
fields are still on the files tab but as checkboxes.

# Expected Behavior Before Changes
The new PDF form fields show up on the descriptions tab.

# Expected Behavior After Changes
The new PDF form fields are hidden on the descriptions tab.
