### PR TITLE
🐛 Fix unpermitted params

### DIFF
--- a/app/forms/hyrax/pdf_form_behavior.rb
+++ b/app/forms/hyrax/pdf_form_behavior.rb
@@ -9,13 +9,18 @@ module Hyrax
 
       self.terms += %i[show_pdf_viewer show_pdf_download_button]
       self.hidden_terms = %i[show_pdf_viewer show_pdf_download_button]
-      # Not sure why this is needed but the form was not working without it
-      # it was getting a Unpermitted parameter error for these terms
-      permitted_params << %i[show_pdf_viewer show_pdf_download_button]
     end
 
     def hidden?(key)
       hidden_terms.include? key.to_sym
+    end
+
+    class_methods do
+      # Not sure why this is needed but the form was no working without it
+      # it was getting an Unpermitted paratemter error for these terms
+      def permitted_params
+        super + %i[show_pdf_viewer show_pdf_download_button]
+      end
     end
   end
 end


### PR DESCRIPTION
This commit will fix the unpermitted params error that occurs when trying to save the form.  It seemed that shoveling the terms in broke functionality for other terms.  Instead we override the class method and add it to the array of terms.
