### PR TITLE
🎁 Add new properties to Images work type

### DIFF
--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -7,6 +7,18 @@ module Hyrax
     include Hyrax::FormTerms
     self.model_class = ::Image
     include PdfFormBehavior
-    self.terms += %i[resource_type extent]
+    self.terms += %i[resource_type
+                     extent
+                     additional_rights_info
+                     bibliographic_citation
+                     institution
+                     types
+                     format
+                     video_embed]
+    self.required_fields += %i[abstract
+                               date_created
+                               resource_type
+                               types]
+    self.terms -= %i[based_near]
   end
 end

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -9,13 +9,65 @@ class Image < ActiveFedora::Base
   )
   include PdfBehavior
 
+  validates :title, presence: { message: 'Your work must have a title.' }
+  validates :creator, presence: { message: 'Your work must have a creator.' }
+  validates :abstract, presence: { message: 'Your work must have an abstract.' }
+  # rubocop:disable Style/RegexpLiteral
+  validates :video_embed,
+            format: {
+              # regex matches only youtube & vimeo urls that are formatted as embed links.
+              with: /(http:\/\/|https:\/\/)(www\.)?(player\.vimeo\.com|youtube\.com\/embed)/,
+              message: "Error: must be a valid YouTube or Vimeo Embed URL."
+            },
+            if: :video_embed?
+  # rubocop:enable Style/RegexpLiteral
+
+  def video_embed?
+    video_embed.present?
+  end
+
+  property :source_identifier, predicate: ::RDF::URI.new("https://atla.com/terms/sourceIdentifier"), multiple: false
+
   property :extent, predicate: ::RDF::Vocab::DC.extent, multiple: true do |index|
+    index.as :stored_searchable
+  end
+
+  property :additional_rights_info,
+           predicate: ::RDF::URI("https://atla.com/terms/additionalRightsInfo"),
+           multiple: true do |index|
+    index.as :stored_searchable
+  end
+
+  property :institution,
+           predicate: ::RDF::Vocab::ORG.organization,
+           multiple: false do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  # types must be initially defined before the include ::Hyrax::BasicMetadata
+  # so that it can be added to the metadata schema
+  # and then be overridden below to map to DC.type.
+  property :types, predicate: ::RDF::URI.new("https://atla.com/terms/types")
+
+  property :format, predicate: ::RDF::Vocab::DC11.format do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :video_embed, predicate: ::RDF::URI("https://atla.com/terms/videoEmbed"), multiple: false do |index|
     index.as :stored_searchable
   end
 
   # This must come after the properties because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata
+
+  property :resource_type, predicate: ::RDF::URI.new("https://atla.com/terms/resourceType") do |index|
+    index.as :stored_searchable, :facetable
+  end
+
+  property :types, predicate: ::RDF::Vocab::DC.type do |index|
+    index.as :stored_searchable, :facetable
+  end
 
   self.indexer = ImageIndexer
   # Change this to restrict which works can be added as a child.

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -6,5 +6,11 @@ module Hyrax
   class ImagePresenter < Hyku::WorkShowPresenter
     # We do not use this generated ImagePresenter. Instead we use the
     # WorkShowPresenter
+    delegate :additional_rights_info,
+             :bibliographic_citation,
+             :institution,
+             :types,
+             :format,
+             to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -42,4 +42,4 @@
 <%= presenter.attribute_to_html(:institution, render_as: :faceted, html_dl: true) %>
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
-<%= presenter.attribute_to_html(:extent) %>
+<%= presenter.attribute_to_html(:extent, html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1194,7 +1194,14 @@ en:
         video_embed: "Youtube or Vimeo iframe embed code to show video embedded in the work page. If you enter an embed link for a video, it must be a properly formatted url beginning with 'http://' or 'https://'. It also needs to contain a valid link to a hosted video that can appear in an iframe. <br /><br /><i>Examples:<br/>https://player.vimeo.com/video/467264493?h=b089de0eab<br/>https://www.youtube.com/embed/Znf73dsFdC8</i>"
       generic_work:
         subject: Headings or index terms describing what the work is about. Please use <a href='https://fast.oclc.org/searchfast/'>FAST subject headings</a> or another controlled vocabulary only.
-
+      image:
+        alternative_title: Alternative title for the resource.
+        date_created: The date on which the work was created. Must adhere to either the format YYYY, YYYY-MM, or YYYY-MM-DD in order to be filtered and sorted.
+        institution: Participating institution to which the work is being uploaded to.
+        license: Licensing and distribution information governing access to the work. Select from the provided drop-down list.
+        resource_type: Pre-defined categories to describe the type of content being uploaded, such as "article" or "photograph." More than one resource type may be selected.
+        subject: Headings or index terms describing what the work is about. Use a controlled vocabulary.
+        types: Pre-defined categories to describe the nature or genre of the resource. More than one type may be selected.
     labels:
       collection:
         size: Size


### PR DESCRIPTION
# Story

This commit will add new properties to the Images work type. The new properties are:

  additional_rights_info
  institution
  resource_type
  types
  format
  video_embed

Ref:
  - https://github.com/scientist-softserv/atla-hyku/issues/145

# Expected Behavior Before Changes
Image work type was just had the default metadata

# Expected Behavior After Changes
Image work type has customized metadata

# Screenshots / Video

<details>
<summary>Form</summary>

![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/dc482e67-1ef4-4164-b9b2-0739b1d5a207)

</details>

<details>
<summary>Record</summary>

![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/d3ab9bbe-a290-4b06-9094-c595f03c33d6)

</details>
