### PR TITLE
🐛 Fix work thumbnails not showing on collections

### DIFF
--- a/app/assets/stylesheets/atla-overrides.scss
+++ b/app/assets/stylesheets/atla-overrides.scss
@@ -6,6 +6,8 @@ html, body.public-facing {
 body {font-size:0.875em;}
 
 img {max-width:100%;}
+// the above override made some thumbnails disappear, so this is a fix for that
+img.file_listing_thumbnail {max-width:none;}
 
 a#skip-to-content{padding:0;}
 


### PR DESCRIPTION
# Story

This commit will target the thumbnails and set the max-width to none. There was a previous override right above it that was setting it to 100% that made them not display.

Ref:
  - https://github.com/scientist-softserv/atla-hyku/issues/172

# Expected Behavior Before Changes
Work thumbnails were not showing up in the collection show page.

# Expected Behavior After Changes
Work thumbnails now show up in the collection show page.

# Screenshots / Video

## Before
![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/e8e88a3f-6323-4f2c-b135-18b78c21e276)

## After
![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/04b060b2-b334-4519-aa03-b70a5a0c5477)
