### PR TITLE
🐛 Fix custom thumbnail showing on searches

### DIFF
--- a/app/views/catalog/_index_gallery_collection_wrapper.html.erb
+++ b/app/views/catalog/_index_gallery_collection_wrapper.html.erb
@@ -1,8 +1,9 @@
-<%# OVERRIDE Hyrax 3.4.1: make collection thumbnail a link so it matches works %>
-<div class="document col-xs-6 col-md-3">
+<%# OVERRIDE: Hyrax 3.5 to use render_thumbnail_tag for gallery view partial %>
+<div class="document col-6 col-md-3">
   <div class="thumbnail">
-    <% value = collection_thumbnail(document, {}, counter: document_counter_with_offset(document_counter)) %>
-    <%= link_to value, generate_work_url(document.to_h, request)%>
+    <%# OVERRIDE begin %>
+    <%= render_thumbnail_tag document, {}, { full_url: true } %>
+    <%# OVERRIDE end %>
     <div class="caption">
       <%= render_document_partials document, blacklight_config.view_config(:gallery).partials, :document_counter => document_counter %>
     </div>

--- a/app/views/catalog/_thumbnail_list_collection.html.erb
+++ b/app/views/catalog/_thumbnail_list_collection.html.erb
@@ -1,5 +1,0 @@
-<%# Override Hyrax 3.4.1 to remove thumbnail link supression and use default collection thumbnail %>
-<div class="col-md-2">
-  <% value = collection_thumbnail(document, {}, counter: document_counter_with_offset(document_counter)) %>
-  <%= link_to value, generate_work_url(document.to_h, request)%>
-</div>


### PR DESCRIPTION
# Story

This commit will remove a Hyrax override that seemed to be causing some issues with the search list view and also bring in a fix from PALs with to address the search gallery view.

Ref:
  - https://github.com/scientist-softserv/atla-hyku/issues/122
  - https://github.com/scientist-softserv/palni-palci/pull/540

# Expected Behavior Before Changes
Custom thumbnails were not showing up in list and gallery search views.

# Expected Behavior After Changes
Custom thumbnails now show up correctly.

# Screenshots / Video

List view:
![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/31597ee5-e2cb-419e-afcf-9d41029750f9)

Gallery view:
![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/8762ca2c-00ae-41a1-9ffc-c5fdb6fe8f14)
