### PR TITLE
🐛 [i119] - add symlink to public/branding

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -91,6 +91,7 @@ RUN sh -l -c " \
   sed -i '/require .enumerator./d' /usr/local/bundle/gems/csl-1.6.0/lib/csl.rb"
 COPY --chown=1001:101 $APP_PATH/bin/db-migrate-seed.sh /app/samvera/
 COPY --chown=1001:101 $APP_PATH /app/samvera/hyrax-webapp
+RUN ln -sf /app/samvera/branding /app/samvera/hyrax-webapp/public/branding
 
 RUN RAILS_ENV=production SECRET_KEY_BASE=`bin/rake secret` DB_ADAPTER=nulldb DB_URL='postgresql://fake' bundle exec rake assets:precompile && yarn install
 CMD ./bin/web


### PR DESCRIPTION
This commit is required to resolve the issue with uploading images from the Collections' branding tab. Because the symlink wasn't established, a user would not be able to see the images they uploaded even though the path correctly exists.

Issue:
- https://github.com/scientist-softserv/atla-hyku/issues/119

BEFORE: 

![image](https://github.com/scientist-softserv/atla-hyku/assets/10081604/d01cad74-5668-41e7-af5a-6ed686448994)




AFTER: 

![image](https://github.com/scientist-softserv/atla-hyku/assets/10081604/5838d0de-0d8a-409e-9e1d-bfde319309bc)



![image](https://github.com/scientist-softserv/atla-hyku/assets/10081604/d7d661cd-6a58-454a-9435-26d44f201517)


