### PR TITLE
🎁 Add location property to all work types

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -88,6 +88,7 @@ class CatalogController < ApplicationController
     config.add_facet_field 'event_title_sim', limit: 5, label: 'Event Title'
     config.add_facet_field 'event_date_sim', limit: 5, label: 'Event Date'
     config.add_facet_field 'institution_sim', limit: 5, label: 'Host Institution'
+    config.add_facet_field 'location_sim', limit: 5, label: 'Location'
     # config.add_facet_field 'based_near_label_sim', limit: 5
 
     # Have BL send all facet field names to Solr, which has been the default
@@ -156,6 +157,7 @@ class CatalogController < ApplicationController
     config.add_show_field 'advisor_tesim', label: 'Advisor'
     config.add_show_field 'committee_member_tesim', label: 'Committee member'
     config.add_show_field 'department_tesim', label: 'Department'
+    config.add_show_field 'location_tesim', label: 'Location'
 
     # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields
@@ -363,6 +365,14 @@ class CatalogController < ApplicationController
 
     config.add_search_field('extent') do |field|
       solr_name = 'extent_tesim'
+      field.solr_local_parameters = {
+        qf: solr_name,
+        pf: solr_name
+      }
+    end
+
+    config.add_search_field('location') do |field|
+      solr_name = 'location_tesim'
       field.solr_local_parameters = {
         qf: solr_name,
         pf: solr_name

--- a/app/forms/hyrax/etd_form.rb
+++ b/app/forms/hyrax/etd_form.rb
@@ -45,7 +45,7 @@ module Hyrax
                     visibility_during_embargo embargo_release_date visibility_after_embargo
                     visibility_during_lease lease_expiration_date visibility_after_lease
                     visibility ordered_member_ids source in_works_ids
-                    member_of_collection_ids admin_set_id]
+                    member_of_collection_ids admin_set_id location]
 
     self.terms -= %i[
       based_near

--- a/app/forms/hyrax/generic_work_form.rb
+++ b/app/forms/hyrax/generic_work_form.rb
@@ -28,7 +28,7 @@ module Hyrax
                     visibility_after_embargo
                     visibility_during_lease lease_expiration_date visibility_after_lease
                     visibility ordered_member_ids source in_works_ids
-                    member_of_collection_ids admin_set_id]
+                    member_of_collection_ids admin_set_id location]
 
     self.required_fields += %i[
       title

--- a/app/forms/hyrax/image_form.rb
+++ b/app/forms/hyrax/image_form.rb
@@ -14,7 +14,8 @@ module Hyrax
                      institution
                      types
                      format
-                     video_embed]
+                     video_embed
+                     location]
     self.required_fields += %i[abstract
                                date_created
                                resource_type

--- a/app/forms/hyrax/paper_or_report_form.rb
+++ b/app/forms/hyrax/paper_or_report_form.rb
@@ -48,7 +48,7 @@ module Hyrax
                     visibility_during_embargo embargo_release_date visibility_after_embargo
                     visibility_during_lease lease_expiration_date visibility_after_lease
                     visibility ordered_member_ids source in_works_ids
-                    member_of_collection_ids admin_set_id]
+                    member_of_collection_ids admin_set_id location]
 
     self.terms -= %i[
       description

--- a/app/models/etd.rb
+++ b/app/models/etd.rb
@@ -90,6 +90,10 @@ class Etd < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :location, predicate: ::RDF::Vocab::DC.coverage do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # types must be initially defined before the include ::Hyrax::BasicMetadata
   # so that it can be added to the metadata schema
   # and then be overridden below to map to DC.type.

--- a/app/models/generic_work.rb
+++ b/app/models/generic_work.rb
@@ -44,6 +44,10 @@ class GenericWork < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :location, predicate: ::RDF::Vocab::DC.coverage do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # types must be initially defined before the include ::Hyrax::BasicMetadata
   # so that it can be added to the metadata schema
   # and then be overridden below to map to DC.type.

--- a/app/models/image.rb
+++ b/app/models/image.rb
@@ -54,6 +54,10 @@ class Image < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :location, predicate: ::RDF::Vocab::DC.coverage do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # This must come after the properties because it finalizes the metadata
   # schema (by adding accepts_nested_attributes)
   include ::Hyrax::BasicMetadata

--- a/app/models/paper_or_report.rb
+++ b/app/models/paper_or_report.rb
@@ -94,6 +94,10 @@ class PaperOrReport < ActiveFedora::Base
     index.as :stored_searchable
   end
 
+  property :location, predicate: ::RDF::Vocab::DC.coverage do |index|
+    index.as :stored_searchable, :facetable
+  end
+
   # types must be initially defined before the include ::Hyrax::BasicMetadata
   # so that it can be added to the metadata schema
   # and then be overridden below to map to DC.type.

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -56,6 +56,7 @@ class SolrDocument
   attribute :language, Solr::Array, 'language_tesim'
   # attribute :level, Solr::Array, 'level_tesim'
   attribute :license, Solr::Array, 'license_tesim'
+  attribute :location, Solr::Array, 'location_tesim'
   attribute :official_link, Solr::Array, 'official_link_tesim'
   attribute :project_name, Solr::Array, 'project_name_tesim'
   attribute :rendering_ids, Solr::Array, 'hasFormat_ssim'

--- a/app/presenters/hyrax/etd_presenter.rb
+++ b/app/presenters/hyrax/etd_presenter.rb
@@ -16,6 +16,7 @@ module Hyrax
              :committee_member,
              :types,
              :department,
+             :location,
              :year, to: :solr_document
   end
 end

--- a/app/presenters/hyrax/generic_work_presenter.rb
+++ b/app/presenters/hyrax/generic_work_presenter.rb
@@ -10,6 +10,7 @@ module Hyrax
              :types,
              :additional_rights_info,
              :bibliographic_citation,
+             :location,
              to: :solr_document
   end
 end

--- a/app/presenters/hyrax/image_presenter.rb
+++ b/app/presenters/hyrax/image_presenter.rb
@@ -11,6 +11,7 @@ module Hyrax
              :institution,
              :types,
              :format,
+             :location,
              to: :solr_document
   end
 end

--- a/app/presenters/hyrax/paper_or_report_presenter.rb
+++ b/app/presenters/hyrax/paper_or_report_presenter.rb
@@ -19,6 +19,7 @@ module Hyrax
              :event_location,
              :event_date,
              :types,
+             :location,
              :official_link, to: :solr_document
   end
 end

--- a/app/views/hyrax/base/_attribute_rows.html.erb
+++ b/app/views/hyrax/base/_attribute_rows.html.erb
@@ -43,3 +43,4 @@
 <%= presenter.attribute_to_html(:date_modified, label: t('hyrax.base.show.last_modified'), html_dl: true) %>
 <%= presenter.attribute_to_html(:based_near_label, html_dl: true) %>
 <%= presenter.attribute_to_html(:extent, html_dl: true) %>
+<%= presenter.attribute_to_html(:location, render_as: :faceted, html_dl: true) %>

--- a/config/locales/hyrax.en.yml
+++ b/config/locales/hyrax.en.yml
@@ -1184,6 +1184,7 @@ en:
         keyword: Words or phrases you select to describe what the work is about. These do not need to be a controlled vocabulary.
         language: The language of the work's content. Spell out the language and capitalize the first letter.
         license: Licensing and distribution information governing access to the work. Select from the provided drop-down list. For more about Creative Commons licenses visit <a href="https://creativecommons.org/licenses/">https://creativecommons.org/licenses/</a>
+        location: Spatial characteristics of the resource. Geographic location relevant to the original item.
         publisher: The person or group responsible for making the original resource available.
         related_url: A link to a website or other specific content (audio, video, PDF document) related to the work. An example is the URL of a research project from which the work was derived.
         resource_type: Pre-defined categories to describe the nature or genre of the resource, such as "article" or "photograph." More than one resource type may be selected.

--- a/spec/forms/hyrax/etd_form_spec.rb
+++ b/spec/forms/hyrax/etd_form_spec.rb
@@ -24,7 +24,8 @@ RSpec.describe Hyrax::EtdForm do
         degree: ['Degree'],
         # level: ['Level'],
         discipline: ['Discipline'],
-        degree_granting_institution: ['Degree Granting Inst']
+        degree_granting_institution: ['Degree Granting Inst'],
+        location: ['San Diego, CA']
       }
     end
 
@@ -39,6 +40,7 @@ RSpec.describe Hyrax::EtdForm do
       # expect(subject['level']).to eq ['Level']
       expect(subject['discipline']).to eq ['Discipline']
       expect(subject['degree_granting_institution']).to eq ['Degree Granting Inst']
+      expect(subject['location']).to eq ['San Diego, CA']
     end
   end
 end

--- a/spec/forms/hyrax/generic_work_form_spec.rb
+++ b/spec/forms/hyrax/generic_work_form_spec.rb
@@ -12,12 +12,14 @@ RSpec.describe Hyrax::GenericWorkForm do
     let(:attributes) do
       {
         title: ['foo'],
-        rendering_ids: [file_set.id]
+        rendering_ids: [file_set.id],
+        location: ['San Diego, CA']
       }
     end
 
     it 'permits parameters' do
       expect(subject['rendering_ids']).to eq [file_set.id]
+      expect(subject['location']).to eq ['San Diego, CA']
     end
   end
 

--- a/spec/forms/hyrax/image_form_spec.rb
+++ b/spec/forms/hyrax/image_form_spec.rb
@@ -15,14 +15,14 @@ RSpec.describe Hyrax::ImageForm do
     let(:attributes) do
       {
         title: ['foo'],
-        extent: ['extent']
+        extent: ['extent'],
+        location: ['San Diego, CA']
       }
     end
 
     it 'permits parameters' do
       expect(subject['extent']).to eq ['extent']
+      expect(subject['location']).to eq ['San Diego, CA']
     end
   end
-
-  include_examples("work_form")
 end

--- a/spec/forms/hyrax/paper_or_report_form_spec.rb
+++ b/spec/forms/hyrax/paper_or_report_form_spec.rb
@@ -17,7 +17,8 @@ RSpec.describe Hyrax::PaperOrReportForm do
       {
         title: ['Title'],
         creator: ['Creator'],
-        institution: 'Institution'
+        institution: 'Institution',
+        location: ['San Diego, CA']
       }
     end
 
@@ -25,6 +26,7 @@ RSpec.describe Hyrax::PaperOrReportForm do
       expect(subject['title']).to eq ['Title']
       expect(subject['creator']).to eq ['Creator']
       expect(subject['institution']).to eq 'Institution'
+      expect(subject['location']).to eq ['San Diego, CA']
     end
   end
 end

--- a/spec/models/etd_spec.rb
+++ b/spec/models/etd_spec.rb
@@ -41,6 +41,7 @@ RSpec.describe Etd do
       expect(subject).to respond_to(:year)
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:institution)
+      expect(subject).to respond_to(:location)
     end
   end
 end

--- a/spec/models/generic_work_spec.rb
+++ b/spec/models/generic_work_spec.rb
@@ -162,6 +162,7 @@ RSpec.describe GenericWork do
       expect(subject).to respond_to(:admin_set_id)
       expect(subject).to respond_to(:embargo_id)
       expect(subject).to respond_to(:lease_id)
+      expect(subject).to respond_to(:location)
     end
   end
   # rubocop:enable RSpec/ExampleLength

--- a/spec/models/image_spec.rb
+++ b/spec/models/image_spec.rb
@@ -9,4 +9,52 @@ RSpec.describe Image do
 
     it { is_expected.to eq ImageIndexer }
   end
+
+  # rubocop:disable RSpec/ExampleLength
+  describe 'metadata' do
+    it 'has descriptive metadata' do
+      expect(subject).to respond_to(:depositor)
+      expect(subject).to respond_to(:title)
+      expect(subject).to respond_to(:date_uploaded)
+      expect(subject).to respond_to(:date_modified)
+      expect(subject).to respond_to(:state)
+      expect(subject).to respond_to(:proxy_depositor)
+      expect(subject).to respond_to(:on_behalf_of)
+      expect(subject).to respond_to(:arkivo_checksum)
+      expect(subject).to respond_to(:owner)
+      expect(subject).to respond_to(:institution)
+      expect(subject).to respond_to(:format)
+      expect(subject).to respond_to(:alternative_title)
+      expect(subject).to respond_to(:label)
+      expect(subject).to respond_to(:import_url)
+      expect(subject).to respond_to(:resource_type)
+      expect(subject).to respond_to(:creator)
+      expect(subject).to respond_to(:contributor)
+      expect(subject).to respond_to(:description)
+      expect(subject).to respond_to(:abstract)
+      expect(subject).to respond_to(:keyword)
+      expect(subject).to respond_to(:license)
+      expect(subject).to respond_to(:rights_notes)
+      expect(subject).to respond_to(:rights_statement)
+      expect(subject).to respond_to(:access_right)
+      expect(subject).to respond_to(:publisher)
+      expect(subject).to respond_to(:date_created)
+      expect(subject).to respond_to(:subject)
+      expect(subject).to respond_to(:language)
+      expect(subject).to respond_to(:identifier)
+      expect(subject).to respond_to(:related_url)
+      expect(subject).to respond_to(:bibliographic_citation)
+      expect(subject).to respond_to(:source)
+      expect(subject).to respond_to(:is_child)
+      expect(subject).to respond_to(:access_control_id)
+      expect(subject).to respond_to(:representative_id)
+      expect(subject).to respond_to(:thumbnail_id)
+      expect(subject).to respond_to(:rendering_ids)
+      expect(subject).to respond_to(:admin_set_id)
+      expect(subject).to respond_to(:embargo_id)
+      expect(subject).to respond_to(:lease_id)
+      expect(subject).to respond_to(:location)
+    end
+  end
+  # rubocop:enable RSpec/ExampleLength
 end

--- a/spec/models/paper_or_report_spec.rb
+++ b/spec/models/paper_or_report_spec.rb
@@ -29,6 +29,7 @@ RSpec.describe PaperOrReport do
       expect(subject).to respond_to(:creator)
       expect(subject).to respond_to(:rights_statement)
       expect(subject).to respond_to(:institution)
+      expect(subject).to respond_to(:location)
     end
   end
 end

--- a/spec/support/shared_examples_for_generic_work_form.rb
+++ b/spec/support/shared_examples_for_generic_work_form.rb
@@ -2,10 +2,6 @@
 
 RSpec.shared_examples 'generic_work_form' do
   describe '.primary_terms' do
-    it 'does not include the license field' do
-      expect(form.primary_terms).not_to include(:license)
-    end
-
     it 'does not include the secondary_terms field' do
       expect(form.primary_terms).not_to include(:keyword)
       expect(form.primary_terms).not_to include(:alternative_title)
@@ -48,11 +44,7 @@ RSpec.shared_examples 'generic_work_form' do
   end
 
   describe '.secondary_terms' do
-    it 'includes the license field' do
-      expect(form.secondary_terms).to include(:license)
-    end
     it 'includes the secondary_terms' do
-      expect(form.secondary_terms).to include(:license)
       expect(form.secondary_terms).to include(:keyword)
       expect(form.secondary_terms).to include(:alternative_title)
       expect(form.secondary_terms).to include(:contributor)


### PR DESCRIPTION
# Story

This commit will add the `location` property to all work types and adjusts all the forms, models, and presenters to support it.  The `CatalogController` was also updated to support the new property as well as the `SolrDocument` and locale yml.

Ref:
  - https://github.com/scientist-softserv/atla-hyku/issues/148

# Screenshots / Video

![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/f3dec2ee-511b-485b-89db-a455c56c4831)

![image](https://github.com/scientist-softserv/atla-hyku/assets/19597776/bae0d0e5-fca2-447e-8185-1bc26851accc)
