### PR TITLE
Introduces importer permission restrictions

### DIFF
--- a/app/models/ability.rb
+++ b/app/models/ability.rb
@@ -103,10 +103,10 @@ class Ability
   end
 
   def can_import_works?
-    can_create_any_work?
+    admin? || work_importer?
   end
 
   def can_export_works?
-    can_create_any_work?
+    admin? || work_importer?
   end
 end

--- a/app/services/roles_service.rb
+++ b/app/services/roles_service.rb
@@ -17,6 +17,7 @@ class RolesService # rubocop:disable Metrics/ClassLength
   WORK_ROLES = %w[
     work_editor
     work_depositor
+    work_importer
   ].freeze
 
   DEFAULT_ROLES = [ADMIN_ROLE] + COLLECTION_ROLES + USER_ROLES + WORK_ROLES
@@ -39,6 +40,10 @@ class RolesService # rubocop:disable Metrics/ClassLength
     depositors: {
       humanized_name: 'Depositors',
       description: I18n.t('hyku.admin.groups.description.depositors')
+    }.freeze,
+    advanced_depositors: {
+      humanized_name: 'Advanced Depositors',
+      description: I18n.t('hyku.admin.groups.description.advanced_depositors')
     }.freeze
   }.freeze
 
@@ -54,6 +59,9 @@ class RolesService # rubocop:disable Metrics/ClassLength
     }.freeze,
     depositors: {
       roles: %i[work_depositor].freeze
+    }.freeze,
+    advanced_depositors: {
+      roles: %i[work_importer].freeze
     }.freeze
   }.freeze
 

--- a/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
+++ b/app/views/hyrax/dashboard/sidebar/_repository_content.html.erb
@@ -14,12 +14,16 @@
 <% end %>
 
 <% if ENV.fetch('HYKU_BULKRAX_ENABLED', 'true') == 'true' %>
-  <%= menu.nav_link(bulkrax.importers_path) do %>
-    <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+  <% if current_ability.can_import_works? %>
+    <%= menu.nav_link(bulkrax.importers_path) do %>
+      <span class="fa fa-cloud-upload" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.importers') %></span>
+    <% end %>
   <% end %>
 
-  <%= menu.nav_link(bulkrax.exporters_path) do %>
-    <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+  <% if current_ability.can_export_works? %>
+    <%= menu.nav_link(bulkrax.exporters_path) do %>
+      <span class="fa fa-cloud-download" aria-hidden="true"></span> <span class="sidebar-action-text"><%= t('bulkrax.admin.sidebar.exporters') %></span>
+    <% end %>
   <% end %>
 <% end %>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -50,6 +50,7 @@ en:
                            They can also: create Collections, deposit and approve Works, manage Embargoes and Leases,
                            and manage Bulkrax importers and exporters.'
           depositors: Users in this group are allowed to deposit Works into any Admin Set in this tenant.
+          advanced_depositors: Users in this group are allowed to import and export to or from any Admin Set in this tenant.
         flash:
           create:
             failure: Group could not be created
@@ -107,6 +108,7 @@ en:
           admin: Grants unrestricted access to this tenant
           work_depositor: Can deposit Works into any Admin Set in this tenant. Can read, edit, and manage Embargoes / Leases for Works belonging to them
           work_editor: Can create, read, edit, and approve any Work in this tenant, as well as move Works between Admin Sets and manage Embargoes and Leases
+          work_importer: Can import or export works into any Admin Set in this tenant.
           collection_editor: Can create, read, and edit any Collection in this tenant
           collection_manager: Can create, read, edit, and destroy any Collection in this tenant
           collection_reader: Can read any Collection in this tenant

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2023_01_31_202855) do
+ActiveRecord::Schema.define(version: 2023_06_08_153601) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -70,6 +70,9 @@ ActiveRecord::Schema.define(version: 2023_01_31_202855) do
     t.datetime "last_succeeded_at"
     t.string "importerexporter_type", default: "Bulkrax::Importer"
     t.integer "import_attempts", default: 0
+    t.index ["identifier"], name: "index_bulkrax_entries_on_identifier"
+    t.index ["importerexporter_id", "importerexporter_type"], name: "bulkrax_entries_importerexporter_idx"
+    t.index ["type"], name: "index_bulkrax_entries_on_type"
   end
 
   create_table "bulkrax_exporter_runs", force: :cascade do |t|
@@ -152,7 +155,9 @@ ActiveRecord::Schema.define(version: 2023_01_31_202855) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.integer "order", default: 0
+    t.index ["child_id"], name: "index_bulkrax_pending_relationships_on_child_id"
     t.index ["importer_run_id"], name: "index_bulkrax_pending_relationships_on_importer_run_id"
+    t.index ["parent_id"], name: "index_bulkrax_pending_relationships_on_parent_id"
   end
 
   create_table "bulkrax_statuses", force: :cascade do |t|
@@ -166,6 +171,9 @@ ActiveRecord::Schema.define(version: 2023_01_31_202855) do
     t.string "runnable_type"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.index ["error_class"], name: "index_bulkrax_statuses_on_error_class"
+    t.index ["runnable_id", "runnable_type"], name: "bulkrax_statuses_runnable_idx"
+    t.index ["statusable_id", "statusable_type"], name: "bulkrax_statuses_statusable_idx"
   end
 
   create_table "checksum_audit_logs", id: :serial, force: :cascade do |t|

--- a/spec/factories/etds.rb
+++ b/spec/factories/etds.rb
@@ -14,6 +14,7 @@ FactoryBot.define do
     # level { ['level'] }
     discipline { ['discipline'] }
     degree_granting_institution { ['degree_granting_institution'] }
+    abstract { ['some random text'] }
 
     factory :etd_with_one_file do
       before(:create) do |work, evaluator|

--- a/spec/factories/generic_works.rb
+++ b/spec/factories/generic_works.rb
@@ -9,6 +9,7 @@ FactoryBot.define do
     title { ['Test title'] }
     institution { 'institution' }
     format { ['format'] }
+    creator { ['creator'] }
 
     factory :public_generic_work, aliases: [:public_work], traits: [:public]
 

--- a/spec/factories/group.rb
+++ b/spec/factories/group.rb
@@ -54,5 +54,13 @@ FactoryBot.define do
 
       roles { ['work_depositor'] }
     end
+
+    factory :advanced_depositors_group do
+      name { 'advanced_depositors' }
+      humanized_name { 'Advanced Depositors' }
+      description { 'Advanced depositors group' }
+
+      roles { ['work_importer'] }
+    end
   end
 end

--- a/spec/factories/images.rb
+++ b/spec/factories/images.rb
@@ -7,7 +7,7 @@ FactoryBot.define do
     end
 
     title { ["Test title"] }
-
+    creator { ['creator'] }
     identifier do
       %w[
         ISBN:978-83-7659-303-6 978-3-540-49698-4 9790879392788

--- a/spec/factories/roles.rb
+++ b/spec/factories/roles.rb
@@ -28,6 +28,11 @@ FactoryBot.define do
       site_role
     end
 
+    trait :work_importer do
+      name { 'work_importer' }
+      site_role
+    end
+
     trait :collection_manager do
       name { 'collection_manager' }
       site_role

--- a/spec/features/manage_user_groups_and_roles_spec.rb
+++ b/spec/features/manage_user_groups_and_roles_spec.rb
@@ -80,6 +80,7 @@ RSpec.describe "The Manage Users table", type: :feature, js: true, clean: true d
         'Select a role...',
         'Work Editor',
         'Work Depositor',
+        'Work Importer',
         'Collection Manager',
         'Collection Editor',
         'Collection Reader',


### PR DESCRIPTION
# Story

Introduces an Advanced Depositors group with Work Importer role.
Addresses previously failing ability specs.

Refs 
- #123 
- https://github.com/scientist-softserv/atla-hyku/issues/183

# Expected Behavior Before Changes

Importers and exporters are open to everyone

# Expected Behavior After Changes

Only Admin user and those in the Advanced Depositor group will have access to importers and exporters

# Screenshots / Video

<details>
<summary>Screenshots</summary>

### default user with no added permissions
![Screenshot 2023-11-22 at 1 58 08 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/09350e8f-4efd-4e5f-b338-a25c0fa7d9ab)

### when default user tries /importers route
![Screenshot 2023-11-22 at 1 58 45 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/90667c06-603e-46a2-acfc-9fa564396e70)

### user in Advanced Depositors group
![Screenshot 2023-11-22 at 1 59 21 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/59fd06c4-ad78-46ad-b619-4e4c8fa41f1a)

### Admin user
![Screenshot 2023-11-22 at 2 00 16 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/4066af86-b38d-4bd3-b6e9-19953f4a763b)

### New group and role
![Screenshot 2023-11-22 at 2 00 33 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/b2f8cd92-1da8-4970-99a6-fa1fb9aa4175)

</details>

# Notes

- Requires rake task to load roles and groups: `rake hyku:roles:create_default_roles_and_groups`
- Adds new translations to en.yml file only. Requires running a translation service to add other language translations.