### PR TITLE
🐛 Fix "Add to Collection" for page 2+ of works

### DIFF
--- a/app/controllers/hyrax/my/works_controller_decorator.rb
+++ b/app/controllers/hyrax/my/works_controller_decorator.rb
@@ -1,0 +1,20 @@
+# frozen_string_literal: true
+
+##
+# OVERRIDE Hyrax 3.5.0; when Hyrax hits v4.0.0 we can remove this.
+# @see https://github.com/samvera/hyrax/pull/5972
+module Hyrax
+  module My
+    module WorksControllerDecorator
+      private
+
+        def collections_service
+          cloned = clone
+          cloned.params = {}
+          Hyrax::CollectionsService.new(cloned)
+        end
+    end
+  end
+end
+
+Hyrax::My::WorksController.prepend(Hyrax::My::WorksControllerDecorator)


### PR DESCRIPTION
# Story

Prior to this commit, when you were on page 2 of your works and selected a work to add to a collection, the query for available collections would use the page 2 as part of the collection query. This would mean the first 100 collections (default page size) that you had access to add works to were skipped.

With this commit, we omit the query parameters from the works page and then query collections.

Refs #194 

# Expected Behavior Before Changes

When selecting works from page 1 and using `Add to Collection`, user was able to select a collection.
For subsequent pages of works, no collection was found.

# Expected Behavior After Changes

`Add to Collection` button works on all pages of works.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-11-27 at 3 21 28 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/c68d6915-343d-4146-a5d3-420f383170e9)
![Screenshot 2023-11-27 at 3 23 22 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/ba44e077-c89a-4e44-8162-31c5e7ee5011)
![Screenshot 2023-11-27 at 3 23 29 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/d53f8bc3-99f0-4139-ac88-d0281af0184c)


</details>

# Notes