### PR TITLE
Limit importers and exporters by user

### DIFF
--- a/app/controllers/bulkrax/exporters_controller_decorator.rb
+++ b/app/controllers/bulkrax/exporters_controller_decorator.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+# Override Bulkrax main (at v5.3.0) to limit access to only user's own exporters
+module Bulkrax
+  module ExportersControllerDecorator
+    def index
+      # NOTE: We're paginating this in the browser.
+      @exporters = Exporter.order(created_at: :desc)
+      @exporters = @exporters.where(user: current_user) unless current_ability.admin?
+      @exporters = @exporters.all
+
+      add_exporter_breadcrumbs if defined?(::Hyrax)
+    end
+  
+    private
+
+      def check_permissions
+        if current_ability.can_import_works?
+          return true if current_ability.admin?
+          return true unless params.key?(:id)
+          return true if Importer.where(id: params[:id], user: current_user).exists?
+          raise CanCan::AccessDenied
+        else 
+          raise CanCan::AccessDenied
+        end
+      end
+  end
+end
+
+Bulkrax::ExportersController.prepend(Bulkrax::ExportersControllerDecorator)

--- a/app/controllers/bulkrax/exporters_controller_decorator.rb
+++ b/app/controllers/bulkrax/exporters_controller_decorator.rb
@@ -11,18 +11,15 @@ module Bulkrax
 
       add_exporter_breadcrumbs if defined?(::Hyrax)
     end
-  
+
     private
 
       def check_permissions
-        if current_ability.can_import_works?
-          return true if current_ability.admin?
-          return true unless params.key?(:id)
-          return true if Importer.where(id: params[:id], user: current_user).exists?
-          raise CanCan::AccessDenied
-        else 
-          raise CanCan::AccessDenied
-        end
+        raise CanCan::AccessDenied unless current_ability.can_export_works?
+        return true if current_ability.admin?
+        return true unless params.key?(:id)
+        return true if Importer.where(id: params[:id], user: current_user).exists?
+        raise CanCan::AccessDenied
       end
   end
 end

--- a/app/controllers/bulkrax/importers_controller_decorator.rb
+++ b/app/controllers/bulkrax/importers_controller_decorator.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+# Override Bulkrax main (at v5.3.0) to limit access to only user's own importers
+module Bulkrax
+  module ImportersControllerDecorator
+    # GET /importers
+    def index
+      # NOTE: We're paginating this in the browser.
+      @importers = Importer.order(created_at: :desc)
+      @importers = @importers.where(user: current_user) unless current_ability.admin?
+      @importers = @importers.all
+
+      if api_request?
+        json_response('index')
+      elsif defined?(::Hyrax)
+        add_importer_breadcrumbs
+      end
+    end
+
+    private
+
+      def check_permissions
+        if current_ability.can_import_works?
+          return true if current_ability.admin?
+          return true unless params.key?(:id)
+          return true if Importer.where(id: params[:id], user: current_user).exists?
+          raise CanCan::AccessDenied
+        else 
+          raise CanCan::AccessDenied
+        end
+      end
+  end
+end
+
+Bulkrax::ImportersController.prepend(Bulkrax::ImportersControllerDecorator)

--- a/app/controllers/bulkrax/importers_controller_decorator.rb
+++ b/app/controllers/bulkrax/importers_controller_decorator.rb
@@ -20,14 +20,11 @@ module Bulkrax
     private
 
       def check_permissions
-        if current_ability.can_import_works?
-          return true if current_ability.admin?
-          return true unless params.key?(:id)
-          return true if Importer.where(id: params[:id], user: current_user).exists?
-          raise CanCan::AccessDenied
-        else 
-          raise CanCan::AccessDenied
-        end
+        raise CanCan::AccessDenied unless current_ability.can_import_works?
+        return true if current_ability.admin?
+        return true unless params.key?(:id)
+        return true if Importer.where(id: params[:id], user: current_user).exists?
+        raise CanCan::AccessDenied
       end
   end
 end


### PR DESCRIPTION
# Story

Refs
- https://github.com/scientist-softserv/atla-hyku/issues/123

Prior work limited the ability to view the importer and exporter pages by user role, but did not limit what importers and exporters could be seen.

With this work, only admin users can see all importers and exporters, while other users can only see importers and exporters they have created.

# Expected Behavior Before Changes

Users with advanced depositor role can see all importers and exporters.

# Expected Behavior After Changes

Only admin can see all importers and exporters. Advanced depositors can only see what they have created.

# Screenshots / Video

<details>
<summary></summary>

![Screenshot 2023-11-28 at 5 34 02 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/ce644725-fe98-47af-a0b7-c903bbe4a874)

![Screenshot 2023-11-28 at 5 24 52 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/df97260c-a039-416f-a6f3-29b267fc6052)

![Screenshot 2023-11-28 at 5 26 12 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/1d5c32ed-45fd-42ff-8e79-81e9d9125690)

![Screenshot 2023-11-28 at 5 27 32 PM](https://github.com/scientist-softserv/atla-hyku/assets/17851674/a73a963f-df1d-499c-8259-c3868a37f1ed)

</details>

# Notes