### PR TITLE
🧹 Correct spltting typo

### DIFF
--- a/config/features.rb
+++ b/config/features.rb
@@ -19,5 +19,5 @@ Flipflop.configure do
   # Flipflop.default_pdf_viewer? returning `true` means we use PDF.js and `false` means we use IIIF Print.
   feature :default_pdf_viewer,
           default: true,
-          description: "Choose PDF.js or Universal Viewer to render PDFs. UV uses IIIF Print and requires PDF spltting with OCR. Switching from PDF.js to the UV may require re-ingesting of the PDF."
+          description: "Choose PDF.js or Universal Viewer to render PDFs. UV uses IIIF Print and requires PDF splitting with OCR. Switching from PDF.js to the UV may require re-ingesting of the PDF."
 end


### PR DESCRIPTION

# Story

spltting has been corrected to splitting in the feature flipper description for :default_pdf_viewer.

Refs
- https://assaydepot.slack.com/archives/C031E2NF43T/p1701706582689099

# Expected Behavior Before Changes

[Staging](https://demo.atla-hyku.notch8.cloud/admin/features?locale=en)

<img width="1045" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/10081604/8feef8aa-9e3b-43da-9930-e5004de4e48f">

# Expected Behavior After Changes

Local

<img width="717" alt="image" src="https://github.com/scientist-softserv/atla-hyku/assets/10081604/d27ef79a-3879-4a47-8df8-5b62f8ee5e04">




# Notes