### PR TITLE
removed line break in message that comes through as html tag

### DIFF
--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -22,8 +22,7 @@ en:
         accept_until: This invitation will be due in %{due_date}.
         hello: Hello %{email}
         ignore: |-
-          If you don't want to accept the invitation, please ignore this email. 
-          Your account won't be created until you access the link above and set your password.
+          If you don't want to accept the invitation, please ignore this email. Your account won't be created until you access the link above and set your password.
         someone_invited_you: Someone has invited you to %{url}, you can accept it through the link below.
         subject: Invitation instructions
   time:


### PR DESCRIPTION
# Story
The email that is sent when a new user is added had a break tag in it as text. I removed the place where the line breaks in the yml file to fix this. (cant test bcz i these emails currently dont work but seems pretty likely to be a solution)

Refs #issuenumber

# Expected Behavior Before Changes

# Expected Behavior After Changes

# Screenshots / Video

<details>
<summary></summary>

</details>

# Notes