### PR TITLE
🐛 Address `ActionView::Template::Error`

### DIFF
--- a/app/helpers/blacklight/blacklight_helper_behavior.rb
+++ b/app/helpers/blacklight/blacklight_helper_behavior.rb
@@ -331,7 +331,7 @@ module Blacklight
     #
     # @param [String] format suffix
     # @yield
-    def with_format(format, _block)
+    def with_format(format, *, &block)
       old_formats = formats
       self.formats = [format]
       yield


### PR DESCRIPTION
I'm seeing the following in Sentry:

```
ArgumentError
wrong number of arguments (given 1, expected 2)
```

With this commit, we factor towards the correct arity while also allowing additional parameters.
